### PR TITLE
Dev Exit Codes

### DIFF
--- a/lib/time_and_tee_run_by_unit.sh
+++ b/lib/time_and_tee_run_by_unit.sh
@@ -1,3 +1,5 @@
 #!/bin/bash -e
 
 /usr/bin/time -v $libDir/run_by_unit.sh $1 |& tee $outputRunDataDir/logs/$1.log
+exit ${PIPESTATUS[0]}
+


### PR DESCRIPTION
Issue #6 
Using the internal bash variable `PIPESTATUS` (described [here](https://www.shellscript.sh/tips/pipestatus/)) the GNU Parallel can now properly detect exit codes in the run_by_unit scripts and reports them correctly in the `logs/summary.log`

## Changes

- added exit command to `lib/time_and_tee_run_by_unit.sh`
