### PR TITLE
Dev remove lakefim

### DIFF
--- a/lib/snap_and_clip_to_nhd.py
+++ b/lib/snap_and_clip_to_nhd.py
@@ -138,7 +138,7 @@ def subset_vector_layers(hucCode,nwm_streams_fileName,nwm_headwaters_fileName,nh
                 toNode = toNode.iloc[0]
                 downstream_ids = nhd_streams.loc[nhd_streams['FromNode'] == toNode,:].index.tolist()
         #If multiple downstream_ids are returned select the ids that are along the main flow path (i.e. exclude segments that are diversions)
-        if len(set(downstream_ids))>1:
+        if len(downstream_ids)>1:
             relevant_ids = [segment for segment in downstream_ids if DnLevelPat == nhd_streams.loc[segment,'LevelPathI']]
         else:
             relevant_ids = downstream_ids

--- a/lib/snap_and_clip_to_nhd.py
+++ b/lib/snap_and_clip_to_nhd.py
@@ -22,19 +22,19 @@ def subset_vector_layers(hucCode,nwm_streams_fileName,nwm_headwaters_fileName,nh
     # find intersecting lakes and writeout
     print("Subsetting NWM Lakes for HUC{} {}".format(hucUnitLength,hucCode),flush=True)
     nwm_lakes = gpd.read_file(nwm_lakes_fileName, mask = wbd_buffer)
-    print(nwm_lakes)
+
     if not nwm_lakes.empty:
         # perform fill process to remove holes/islands in the NWM lake polygons
-        nwm_lakes_fill = nwm_lakes
+        # nwm_lakes_fill = nwm_lakes.copy()
         nwm_lakes_fill_holes=MultiPolygon(Polygon(p.exterior) for p in nwm_lakes['geometry']) # remove donut hole geometries
         # loop through the filled polygons and insert the new geometry
         for i in range(len(nwm_lakes_fill_holes)):
-            print(str(i))
-            nwm_lakes_fill.loc[i,'geometry'] = nwm_lakes_fill_holes[i]
-        nwm_lakes_fill.crs = projection
-        nwm_lakes = nwm_lakes_fill
+            # nwm_lakes_fill.loc[i,'geometry'] = nwm_lakes_fill_holes[i]
+            nwm_lakes.loc[i,'geometry'] = nwm_lakes_fill_holes[i]
+        # nwm_lakes_fill.crs = projection
+        # nwm_lakes = nwm_lakes_fill.copy()
         nwm_lakes.to_file(subset_nwm_lakes_fileName,driver=getDriver(subset_nwm_lakes_fileName),index=False)
-    del nwm_lakes
+    del nwm_lakes, nwm_lakes_fill_holes #, nwm_lakes_fill
 
     # find intersecting levee lines
     print("Subsetting NLD levee lines for HUC{} {}".format(hucUnitLength,hucCode),flush=True)

--- a/lib/snap_and_clip_to_nhd.py
+++ b/lib/snap_and_clip_to_nhd.py
@@ -25,16 +25,14 @@ def subset_vector_layers(hucCode,nwm_streams_fileName,nwm_headwaters_fileName,nh
 
     if not nwm_lakes.empty:
         # perform fill process to remove holes/islands in the NWM lake polygons
-        # nwm_lakes_fill = nwm_lakes.copy()
+        nwm_lakes = nwm_lakes.explode()
         nwm_lakes_fill_holes=MultiPolygon(Polygon(p.exterior) for p in nwm_lakes['geometry']) # remove donut hole geometries
         # loop through the filled polygons and insert the new geometry
         for i in range(len(nwm_lakes_fill_holes)):
-            # nwm_lakes_fill.loc[i,'geometry'] = nwm_lakes_fill_holes[i]
             nwm_lakes.loc[i,'geometry'] = nwm_lakes_fill_holes[i]
-        # nwm_lakes_fill.crs = projection
-        # nwm_lakes = nwm_lakes_fill.copy()
+
         nwm_lakes.to_file(subset_nwm_lakes_fileName,driver=getDriver(subset_nwm_lakes_fileName),index=False)
-    del nwm_lakes, nwm_lakes_fill_holes #, nwm_lakes_fill
+    del nwm_lakes, nwm_lakes_fill_holes
 
     # find intersecting levee lines
     print("Subsetting NLD levee lines for HUC{} {}".format(hucUnitLength,hucCode),flush=True)

--- a/lib/split_flows.py
+++ b/lib/split_flows.py
@@ -63,6 +63,8 @@ if lakes is not None:
       lakes = lakes.filter(items=['newID', 'geometry'])
       lakes = lakes.set_index('newID')
       flows = gpd.overlay(flows, lakes, how='union').explode().reset_index(drop=True)
+      lakes_buffer = lakes
+      lakes_buffer['geometry'] = lakes_buffer.buffer(20) # adding 10m buffer for spatial join comparison
 
 print ('splitting ' + str(len(flows)) + ' stream segments based on ' + str(maxLength) + ' m max length')
 
@@ -148,7 +150,7 @@ for i,lineString in tqdm(enumerate(flows.geometry),total=len(flows.geometry)):
 split_flows_gdf = gpd.GeoDataFrame({'S0' : slopes ,'geometry':split_flows}, crs=flows.crs, geometry='geometry')
 split_flows_gdf['LengthKm'] = split_flows_gdf.geometry.length * toMetersConversion
 if lakes is not None:
-    split_flows_gdf = gpd.sjoin(split_flows_gdf, lakes, how='left', op='within')
+    split_flows_gdf = gpd.sjoin(split_flows_gdf, lakes_buffer, how='left', op='within') #options: intersects, within, contains, crosses
     split_flows_gdf = split_flows_gdf.rename(columns={"index_right": "LakeID"}).fillna(-999)
 else:
     split_flows_gdf['LakeID'] = -999

--- a/lib/split_flows.py
+++ b/lib/split_flows.py
@@ -63,8 +63,8 @@ if lakes is not None:
       lakes = lakes.filter(items=['newID', 'geometry'])
       lakes = lakes.set_index('newID')
       flows = gpd.overlay(flows, lakes, how='union').explode().reset_index(drop=True)
-      lakes_buffer = lakes
-      lakes_buffer['geometry'] = lakes_buffer.buffer(20) # adding 10m buffer for spatial join comparison
+      lakes_buffer = lakes.copy()
+      lakes_buffer['geometry'] = lakes.buffer(20) # adding 20m buffer for spatial join comparison
 
 print ('splitting ' + str(len(flows)) + ' stream segments based on ' + str(maxLength) + ' m max length')
 

--- a/tests/inundation.py
+++ b/tests/inundation.py
@@ -457,6 +457,7 @@ def __subset_hydroTable_to_forecast(hydroTable,forecast,subset_hucs=None):
                                          'discharge_cms':float,'LakeID' : int}
                                 )
         hydroTable.set_index(['HUC','feature_id','HydroID'],inplace=True)
+        hydroTable = hydroTable[hydroTable["LakeID"] == -999]  # Subset hydroTable to include only non-lake catchments.
     elif isinstance(hydroTable,pd.DataFrame):
         pass #consider checking for correct dtypes, indices, and columns
     else:


### PR DESCRIPTION
This feature branch includes modifications to identify stream segments that overlap NWM lake areas. Our current HAND-FIM methodology and topography data can not adequately capture lake inundation features (i.e. we don’t have lake bathy), so this modification removes inundation output for all catchments that overlap with lake areas. FIM 2.3.3 removed most lake areas from the output inundation raster; therefore this change is also needed to ensure a fair comparison when examining the FIM2 vs. FIM3  #metrics. Resolve issue #106 
![problem_slide](https://user-images.githubusercontent.com/69868854/100263689-70e6f380-2f13-11eb-8037-b83127c6ebba.png)
![problem_FIM2_slide](https://user-images.githubusercontent.com/69868854/100263707-75131100-2f13-11eb-8a43-0b1487803b90.png)


## Changes

### snap_and_clip_to_nhd.py 

- Added code to loop through the NWM lakes multipolygon and remove any holes/islands polygon features (only keeping exterior polygons) and then overwrite the nwm_lakes_proj_subset.gpkg file for later use

### split_flows.py 

- Added code to create a new lakes_buffer feature (20-meter buffer)
- The split function is still using the original (non-buffered) polygon to define the split points at the polygon boundaries
- The new buffered lake polygon is used to perform the geopandas spatial join → any reach segment fully contained (“within” function) in the lakes polygon is assigned a “LakeID” attribute value from the lakes_buffer feature
- All segments that are not contained by the lake polygon are given a default “LakeID” value of -999

### inundation.py 

- Added line of code to filter the hydroTable for locations not associated with NWM lake areas → filter for LakeID = -999 (not a lake)

_Note that these changes appear to improve the identification of lake-associated catchments, but there are instances where catchments are not identified as lake catchments. The example below illustrates a case where the stream reach line meanders outside of the buffered lake polygon boundary. Recall that in order for a reach to be assigned a “LakeID” it must fall entirely within the lake polygon. Future testing and enhancements may be able to improve upon these methods (e.g. increased lake polygon buffer for spatial join, test additional shapely spatial join techniques)._
![shortcomings_example](https://user-images.githubusercontent.com/69868854/100263766-89efa480-2f13-11eb-8683-57f4e3a824f4.png)

## Testing

1. Check out the dev-remove-lakefim branch and run the following:
#### fim_run.sh
`fim_run.sh -u /data/temp/param_adjusted_files/dev_fim_ble_forbrad.lst -c foss_fim/config/params_template.env -n dev_remove_lakefim_FR_review -j 12`
#### ble_autoeval.sh
`/foss_fim/tests/ble_autoeval.sh -f dev_remove_lakefim_FR_review -b /data/temp/param_adjusted_files/dev_fim_ble_forbrad.lst -d dev_c12582e_fr -v "DEV" -s /data/temp/pull_requests/dev_remove_lakefim_FR_review`

2. Compare aggregate CSIs to the following scores:

- FR 100yr: 0.5568
- FR 500yr: 0.5827
- MS 100yr: 0.3845
- MS 500yr: 0.4056

3. Make sure that the final inundation raster is excluding most lake areas & not creating new artifacts:
Use inundation_extent.tif (example hucs with lakes: 11130304)
![MS_results_example](https://user-images.githubusercontent.com/69868854/100263785-8f4cef00-2f13-11eb-94e0-7cf3be2ba09d.png)

## Evaluation Metrics
Note that the metrics show a consistent regression due to the fact that we are removing inundated lake areas from the FIM output. These areas typically represented "True Positive" instances in the previous evaluation metrics.
*To view all statistics --> refer to google drive links

**Full Res 100-yr CSI results (%change is comparing current dev to new feature branch)**
total_area | fim_1_0_0 | fim_2_3_3 | dev_c12582e_fr | new_feature | eval | site | % change
-- | -- | -- | -- | -- | -- | -- | --
CSI | 0.596 | 0.632 | 0.621 | 0.621 | 100yr | 11090202 | -0.06%
CSI | 0.464 | 0.479 | 0.475 | 0.470 | 100yr | 11090203 | -0.98%
CSI | 0.553 | 0.536 | 0.569 | 0.532 | 100yr | 11090204 | -6.37%
CSI | 0.561 | 0.583 | 0.584 | 0.573 | 100yr | 11100303 | -2.01%
CSI | 0.499 | 0.585 | 0.598 | 0.594 | 100yr | 11130302 | -0.71%
CSI | 0.473 | 0.555 | 0.567 | 0.563 | 100yr | 11130303 | -0.63%
CSI | 0.548 | 0.493 | 0.583 | 0.509 | 100yr | 11130304 | -12.63%
CSI | 0.535 | 0.587 | 0.612 | 0.596 | 100yr | 11130301 | -2.52%
CSI | 0.575 | 0.588 | 0.597 | 0.588 | 100yr | 12020001 | -1.58%
CSI | 0.505 | 0.534 | 0.510 | 0.508 | 100yr | 12020002 | -0.32%
CSI | 0.572 | 0.542 | 0.551 | 0.546 | 100yr | 12020003 | -0.98%
CSI | 0.632 | 0.674 | 0.657 | 0.651 | 100yr | 12020004 | -0.83%
CSI | 0.496 | 0.584 | 0.584 | 0.571 | 100yr | 12020005 | -2.23%
CSI | 0.505 | 0.544 | 0.536 | 0.536 | 100yr | 12020006 | 0.00%
CSI | 0.418 | 0.398 | 0.395 | 0.395 | 100yr | 12020007 | 0.00%
CSI | 0.546 | 0.521 | 0.545 | 0.521 | 100yr | 12030104 | -4.53%
CSI | 0.518 | 0.547 | 0.561 | 0.551 | 100yr | 12030107 | -1.93%
CSI | 0.561 | 0.527 | 0.518 | 0.514 | 100yr | 12030108 | -0.77%
CSI | 0.484 | 0.514 | 0.504 | 0.499 | 100yr | 12030109 | -0.92%
CSI | 0.528 | 0.578 | 0.613 | 0.568 | 100yr | 12040101 | -7.41%
CSI | 0.494 | 0.578 | 0.563 | 0.555 | 100yr | 12040103 | -1.39%
CSI | 0.493 | 0.488 | 0.494 | 0.476 | 100yr | 12060202 | -3.77%
CSI | 0.529 | 0.595 | 0.577 | 0.577 | 100yr | 12090301 | -0.07%
CSI | 0.571 | 0.574 | 0.577 | 0.567 | 100yr | 12100201 | -1.68%
CSI | 0.608 | 0.653 | 0.641 | 0.636 | 100yr | 12100202 | -0.72%
CSI | 0.575 | 0.599 | 0.599 | 0.599 | 100yr | 12100203 | 0.00%
CSI | 0.361 | 0.413 | 0.380 | 0.380 | 100yr | 13020101 | 0.00%
CSI | 0.351 | 0.359 | 0.348 | 0.339 | 100yr | 13020102 | -2.58%
CSI |   |   | 0.625 | 0.625 | 100yr | 11010004 | 0.00%
CSI |   |   | 0.787 | 0.787 | 100yr | 11010009 | -0.02%
CSI |   |   | 0.538 | 0.533 | 100yr | 11010014 | -0.99%
CSI |   |   | 0.575 | 0.554 | 100yr | 11110202 | -3.76%
CSI |   |   | 0.583 | 0.582 | 100yr | 11110205 | -0.19%
CSI |   |   | 0.630 | 0.613 | 100yr | 11050003 | -2.81%
CSI |   |   | 0.512 | 0.510 | 100yr | 11120303 | -0.34%
CSI |   |   | 0.498 | 0.496 | 100yr | 11130202 | -0.37%
CSI |   |   | 0.506 | 0.506 | 100yr | 11130203 | -0.03%
CSI |   |   | 0.566 | 0.566 | 100yr | 11130208 | -0.03%
CSI |   |   | 0.635 | 0.635 | 100yr | 11140102 | 0.00%
CSI |   |   | 0.565 | 0.564 | 100yr | 11140103 | -0.25%
CSI |   |   | 0.683 | 0.683 | 100yr | 11140104 | 0.00%
CSI |   |   | 0.621 | 0.595 | 100yr | 11110104 | -4.15%
CSI |   |   | 0.538 | 0.522 | 100yr | 11140105 | -2.93%
CSI |   |   | 0.633 | 0.513 | 100yr | 11070103 | -19.02%
CSI |   |   | 0.534 | 0.508 | 100yr | 8040101 | -4.87%
CSI |   |   | 0.645 | 0.644 | 100yr | 8040203 | -0.25%
CSI |   |   | 0.400 | 0.395 | 100yr | 12060102 | -1.34%
CSI |   |   | 0.558 | 0.558 | 100yr | 8070201 | 0.00%


**Mainstem 100-yr CSI results (%change is comparing current dev to new feature branch)**
total_area | fim_1_0_0 | fim_2_3_3 | dev_c12582e_fr | new_feature | eval | site | % change
-- | -- | -- | -- | -- | -- | -- | --
CSI | 0.596 | 0.632 | 0.552 | 0.552 | 100yr | 11090202 | 0.00%
CSI | 0.464 | 0.479 | 0.350 | 0.350 | 100yr | 11090203 | 0.00%
CSI | 0.553 | 0.536 | 0.489 | 0.416 | 100yr | 11090204 | -14.93%
CSI | 0.561 | 0.583 | 0.478 | 0.424 | 100yr | 11100303 | -11.19%
CSI | 0.499 | 0.585 | 0.469 | 0.469 | 100yr | 11130302 | 0.00%
CSI | 0.473 | 0.555 | 0.362 | 0.362 | 100yr | 11130303 | 0.00%
CSI | 0.548 | 0.493 | 0.433 | 0.362 | 100yr | 11130304 | -16.29%
CSI | 0.535 | 0.587 | 0.288 | 0.254 | 100yr | 11130301 | -11.91%
CSI | 0.575 | 0.588 | 0.296 | 0.283 | 100yr | 12020001 | -4.34%
CSI | 0.505 | 0.534 | 0.299 | 0.299 | 100yr | 12020002 | 0.00%
CSI | 0.572 | 0.542 | 0.361 | 0.358 | 100yr | 12020003 | -0.88%
CSI | 0.632 | 0.674 | 0.451 | 0.446 | 100yr | 12020004 | -1.04%
CSI | 0.496 | 0.584 | 0.219 | 0.175 | 100yr | 12020005 | -20.09%
CSI | 0.505 | 0.544 | 0.323 | 0.323 | 100yr | 12020006 | 0.00%
CSI | 0.418 | 0.398 | 0.233 | 0.233 | 100yr | 12020007 | 0.00%
CSI | 0.546 | 0.521 | 0.346 | 0.307 | 100yr | 12030104 | -11.04%
CSI | 0.518 | 0.547 | 0.289 | 0.261 | 100yr | 12030107 | -9.89%
CSI | 0.561 | 0.527 | 0.275 | 0.271 | 100yr | 12030108 | -1.35%
CSI | 0.484 | 0.514 | 0.214 | 0.209 | 100yr | 12030109 | -2.30%
CSI | 0.528 | 0.578 | 0.529 | 0.430 | 100yr | 12040101 | -18.71%
CSI | 0.494 | 0.578 | 0.363 | 0.343 | 100yr | 12040103 | -5.42%
CSI | 0.493 | 0.488 | 0.339 | 0.306 | 100yr | 12060202 | -9.68%
CSI | 0.529 | 0.595 | 0.396 | 0.396 | 100yr | 12090301 | 0.00%
CSI | 0.571 | 0.574 | 0.414 | 0.404 | 100yr | 12100201 | -2.56%
CSI | 0.608 | 0.653 | 0.490 | 0.482 | 100yr | 12100202 | -1.58%
CSI | 0.575 | 0.599 | 0.460 | 0.460 | 100yr | 12100203 | 0.00%
CSI | 0.351 | 0.359 | 0.279 | 0.255 | 100yr | 13020102 | -8.63%
CSI |   |   | 0.588 | 0.588 | 100yr | 11010004 | 0.00%
CSI |   |   | 0.557 | 0.557 | 100yr | 11010009 | 0.00%
CSI |   |   | 0.251 | 0.251 | 100yr | 11010014 | 0.00%
CSI |   |   | 0.531 | 0.444 | 100yr | 11110202 | -16.37%
CSI |   |   | 0.438 | 0.405 | 100yr | 11050003 | -7.37%
CSI |   |   | 0.366 | 0.366 | 100yr | 11120303 | 0.00%
CSI |   |   | 0.370 | 0.370 | 100yr | 11130202 | 0.00%
CSI |   |   | 0.462 | 0.462 | 100yr | 11130203 | 0.00%
CSI |   |   | 0.311 | 0.311 | 100yr | 11130208 | 0.00%
CSI |   |   | 0.497 | 0.497 | 100yr | 11140102 | 0.00%
CSI |   |   | 0.533 | 0.533 | 100yr | 11140103 | 0.00%
CSI |   |   | 0.326 | 0.326 | 100yr | 11140104 | 0.00%
CSI |   |   | 0.492 | 0.464 | 100yr | 11110104 | -5.74%
CSI |   |   | 0.358 | 0.304 | 100yr | 11140105 | -15.07%
CSI |   |   | 0.532 | 0.345 | 100yr | 11070103 | -35.10%
CSI |   |   | 0.275 | 0.265 | 100yr | 12060102 | -3.72%
CSI | 0.468 | 0.519 | 0.215 | 0.215 | 100yr | 12110110 | 0.00%

