### PR TITLE
[1pt] PR: Remove ocean FIM 

### DIFF
--- a/config/params_calibrated.env
+++ b/config/params_calibrated.env
@@ -2,12 +2,15 @@
 
 #### geospatial parameters ####
 export negativeBurnValue=1000
+export buffer=70
 export maxSplitDistance_meters=1500
 export manning_n="/foss_fim/config/mannings_calibrated.json"
 export stage_min_meters=0
 export stage_interval_meters=0.3048
 export stage_max_meters=25
 export slope_min=0.001
+export ms_buffer_dist=7000
+export lakes_buffer_dist_meters=20
 
 #### computational parameters ####
 export ncores_gw=1 # mpi number of cores for gagewatershed

--- a/config/params_template.env
+++ b/config/params_template.env
@@ -10,6 +10,7 @@ export stage_interval_meters=0.3048
 export stage_max_meters=25
 export slope_min=0.001
 export ms_buffer_dist=7000
+export lakes_buffer_dist_meters=20
 
 #### computational parameters ####
 export ncores_gw=1 # mpi number of cores for gagewatershed

--- a/lib/run_by_unit.sh
+++ b/lib/run_by_unit.sh
@@ -30,7 +30,7 @@ huc2Identifier=${hucNumber:0:2}
 input_NHD_WBHD_layer=WBDHU$hucUnitLength
 input_DEM=$inputDataDir/nhdplus_rasters/HRNHDPlusRasters"$huc4Identifier"/elev_cm.tif
 input_NLD=$inputDataDir/nld_vectors/huc2_levee_lines/nld_preprocessed_"$huc2Identifier".gpkg
-input_LANDSEA=$inputDataDir/nhdplus_vectors/"$huc4Identifier"/NHDPlusLandSea"$huc4Identifier".gpkg
+input_LANDSEA=$inputDataDir/landsea/water_polygons_us.gpkg
 
 ## GET WBD ##
 echo -e $startDiv"Get WBD $hucNumber"$stopDiv
@@ -53,7 +53,7 @@ echo -e $startDiv"Get Vector Layers and Subset $hucNumber"$stopDiv
 date -u
 Tstart
 [ ! -f $outputHucDataDir/NHDPlusBurnLineEvent_subset.gpkg ] && \
-$libDir/snap_and_clip_to_nhd.py -d $hucNumber -w $input_NWM_Flows -f $input_NWM_Headwaters -s $input_NHD_Flowlines -l $input_NWM_Lakes -r $input_NLD -u $outputHucDataDir/wbd.gpkg -g $outputHucDataDir/wbd_buffered.gpkg -y $inputDataDir/ahp_sites/ahps_sites.gpkg -v $input_LANDSEA -c $outputHucDataDir/NHDPlusBurnLineEvent_subset.gpkg -z $outputHucDataDir/nld_subset_levees.gpkg -a $outputHucDataDir/nwm_lakes_proj_subset.gpkg -t $outputHucDataDir/nwm_headwaters_proj_subset.gpkg -m $input_NWM_Catchments -n $outputHucDataDir/nwm_catchments_proj_subset.gpkg -e $outputHucDataDir/nhd_headwater_points_subset.gpkg -x $outputHucDataDir/NHDPlusLandSea_subset.gpkg -b $outputHucDataDir/nwm_subset_streams.gpkg -p $extent
+$libDir/snap_and_clip_to_nhd.py -d $hucNumber -w $input_NWM_Flows -f $input_NWM_Headwaters -s $input_NHD_Flowlines -l $input_NWM_Lakes -r $input_NLD -u $outputHucDataDir/wbd.gpkg -g $outputHucDataDir/wbd_buffered.gpkg -y $inputDataDir/ahp_sites/ahps_sites.gpkg -v $input_LANDSEA -c $outputHucDataDir/NHDPlusBurnLineEvent_subset.gpkg -z $outputHucDataDir/nld_subset_levees.gpkg -a $outputHucDataDir/nwm_lakes_proj_subset.gpkg -t $outputHucDataDir/nwm_headwaters_proj_subset.gpkg -m $input_NWM_Catchments -n $outputHucDataDir/nwm_catchments_proj_subset.gpkg -e $outputHucDataDir/nhd_headwater_points_subset.gpkg -x $outputHucDataDir/LandSea_subset.gpkg -b $outputHucDataDir/nwm_subset_streams.gpkg -p $extent
 Tcount
 
 if [ "$extent" = "MS" ]; then
@@ -234,7 +234,7 @@ echo -e $startDiv"Split Derived Reaches $hucNumber"$stopDiv
 date -u
 Tstart
 [ ! -f $outputHucDataDir/demDerived_reaches_split.gpkg ] && \
-$libDir/split_flows.py $outputHucDataDir/demDerived_reaches.shp $outputHucDataDir/dem_thalwegCond.tif $outputHucDataDir/demDerived_reaches_split.gpkg $outputHucDataDir/demDerived_reaches_split_points.gpkg $maxSplitDistance_meters $slope_min $outputHucDataDir/wbd8_clp.gpkg  $outputHucDataDir/nwm_lakes_proj_subset.gpkg
+$libDir/split_flows.py $outputHucDataDir/demDerived_reaches.shp $outputHucDataDir/dem_thalwegCond.tif $outputHucDataDir/demDerived_reaches_split.gpkg $outputHucDataDir/demDerived_reaches_split_points.gpkg $maxSplitDistance_meters $slope_min $outputHucDataDir/wbd8_clp.gpkg $outputHucDataDir/nwm_lakes_proj_subset.gpkg $lakes_buffer_dist_meters
 Tcount
 
 if [ "$extent" = "MS" ]; then
@@ -349,8 +349,8 @@ Tcount
 echo -e $startDiv"Rasterize filtered/dissolved ocean polygon $hucNumber"$stopDiv
 date -u
 Tstart
-[ -f $outputHucDataDir/NHDPlusLandSea_subset.gpkg ] && [ ! -f $outputHucDataDir/NHDPlusLandSea_subset.tif ] && \
-gdal_rasterize -ot Int32 -a Land -a_nodata $ndv -init 0 -co "COMPRESS=LZW" -co "BIGTIFF=YES" -co "TILED=YES" -te $xmin $ymin $xmax $ymax -ts $ncols $nrows $outputHucDataDir/NHDPlusLandSea_subset.gpkg $outputHucDataDir/NHDPlusLandSea_subset.tif
+[ -f $outputHucDataDir/LandSea_subset.gpkg ] && [ ! -f $outputHucDataDir/LandSea_subset.tif ] && \
+gdal_rasterize -ot Int32 -burn $ndv -a_nodata $ndv -init 1 -co "COMPRESS=LZW" -co "BIGTIFF=YES" -co "TILED=YES" -te $xmin $ymin $xmax $ymax -ts $ncols $nrows $outputHucDataDir/LandSea_subset.gpkg $outputHucDataDir/LandSea_subset.tif
 Tcount
 
 ## MASK SLOPE RASTER ##
@@ -370,11 +370,11 @@ gdal_calc.py --quiet --type=Float32 --overwrite --co "COMPRESS=LZW" --co "BIGTIF
 Tcount
 
 ## MASK REM RASTER TO REMOVE OCEAN AREAS ##
-echo -e $startDiv"Masking REM Raster to remove ocean areas to HUC $hucNumber (overwrites REM)"$stopDiv
+echo -e $startDiv"Additional masking to REM raster to remove ocean areas in HUC $hucNumber (if applicable)"$stopDiv
 date -u
 Tstart
-[ -f $outputHucDataDir/NHDPlusLandSea_subset.tif ] && \
-gdal_calc.py --quiet --type=Float32 --overwrite --co "COMPRESS=LZW" --co "BIGTIFF=YES" --co "TILED=YES" -A $outputHucDataDir/rem_zeroed_masked.tif -B $outputHucDataDir/NHDPlusLandSea_subset.tif --calc="(A+((B<0)*$ndv))" --NoDataValue=$ndv --outfile=$outputHucDataDir/"rem_zeroed_masked.tif"
+[ -f $outputHucDataDir/LandSea_subset.tif ] && \
+gdal_calc.py --quiet --type=Float32 --overwrite --co "COMPRESS=LZW" --co "BIGTIFF=YES" --co "TILED=YES" -A $outputHucDataDir/rem_zeroed_masked.tif -B $outputHucDataDir/LandSea_subset.tif --calc="(A*B)" --NoDataValue=$ndv --outfile=$outputHucDataDir/"rem_zeroed_masked.tif"
 Tcount
 
 ## MAKE CATCHMENT AND STAGE FILES ##

--- a/lib/run_by_unit.sh
+++ b/lib/run_by_unit.sh
@@ -30,6 +30,7 @@ huc2Identifier=${hucNumber:0:2}
 input_NHD_WBHD_layer=WBDHU$hucUnitLength
 input_DEM=$inputDataDir/nhdplus_rasters/HRNHDPlusRasters"$huc4Identifier"/elev_cm.tif
 input_NLD=$inputDataDir/nld_vectors/huc2_levee_lines/nld_preprocessed_"$huc2Identifier".gpkg
+input_LANDSEA=$inputDataDir/nhdplus_vectors/"$huc4Identifier"/NHDPlusLandSea"$huc4Identifier".gpkg
 
 ## GET WBD ##
 echo -e $startDiv"Get WBD $hucNumber"$stopDiv
@@ -52,7 +53,7 @@ echo -e $startDiv"Get Vector Layers and Subset $hucNumber"$stopDiv
 date -u
 Tstart
 [ ! -f $outputHucDataDir/NHDPlusBurnLineEvent_subset.gpkg ] && \
-$libDir/snap_and_clip_to_nhd.py -d $hucNumber -w $input_NWM_Flows -f $input_NWM_Headwaters -s $input_NHD_Flowlines -l $input_NWM_Lakes -r $input_NLD -u $outputHucDataDir/wbd.gpkg -g $outputHucDataDir/wbd_buffered.gpkg -y $inputDataDir/ahp_sites/ahps_sites.gpkg -c $outputHucDataDir/NHDPlusBurnLineEvent_subset.gpkg -z $outputHucDataDir/nld_subset_levees.gpkg -a $outputHucDataDir/nwm_lakes_proj_subset.gpkg -t $outputHucDataDir/nwm_headwaters_proj_subset.gpkg -m $input_NWM_Catchments -n $outputHucDataDir/nwm_catchments_proj_subset.gpkg -e $outputHucDataDir/nhd_headwater_points_subset.gpkg -b $outputHucDataDir/nwm_subset_streams.gpkg -p $extent
+$libDir/snap_and_clip_to_nhd.py -d $hucNumber -w $input_NWM_Flows -f $input_NWM_Headwaters -s $input_NHD_Flowlines -l $input_NWM_Lakes -r $input_NLD -u $outputHucDataDir/wbd.gpkg -g $outputHucDataDir/wbd_buffered.gpkg -y $inputDataDir/ahp_sites/ahps_sites.gpkg -v $input_LANDSEA -c $outputHucDataDir/NHDPlusBurnLineEvent_subset.gpkg -z $outputHucDataDir/nld_subset_levees.gpkg -a $outputHucDataDir/nwm_lakes_proj_subset.gpkg -t $outputHucDataDir/nwm_headwaters_proj_subset.gpkg -m $input_NWM_Catchments -n $outputHucDataDir/nwm_catchments_proj_subset.gpkg -e $outputHucDataDir/nhd_headwater_points_subset.gpkg -b $outputHucDataDir/nwm_subset_streams.gpkg -p $extent
 Tcount
 
 if [ "$extent" = "MS" ]; then

--- a/lib/split_flows.py
+++ b/lib/split_flows.py
@@ -31,7 +31,7 @@ maxLength              = float(sys.argv[5])
 slope_min              = float(sys.argv[6])
 huc8_filename          = sys.argv[7]
 lakes_filename         = sys.argv[8]
-lakes_buffer_input     = sys.argv[9]
+lakes_buffer_input     = float(sys.argv[9])
 
 toMetersConversion = 1e-3
 

--- a/lib/split_flows.py
+++ b/lib/split_flows.py
@@ -31,6 +31,7 @@ maxLength              = float(sys.argv[5])
 slope_min              = float(sys.argv[6])
 huc8_filename          = sys.argv[7]
 lakes_filename         = sys.argv[8]
+lakes_buffer_input     = sys.argv[9]
 
 toMetersConversion = 1e-3
 
@@ -64,7 +65,7 @@ if lakes is not None:
       lakes = lakes.set_index('newID')
       flows = gpd.overlay(flows, lakes, how='union').explode().reset_index(drop=True)
       lakes_buffer = lakes.copy()
-      lakes_buffer['geometry'] = lakes.buffer(20) # adding 20m buffer for spatial join comparison
+      lakes_buffer['geometry'] = lakes.buffer(lakes_buffer_input) # adding X meter buffer for spatial join comparison (currently using 20meters)
 
 print ('splitting ' + str(len(flows)) + ' stream segments based on ' + str(maxLength) + ' m max length')
 

--- a/tests/aggregate_metrics.py
+++ b/tests/aggregate_metrics.py
@@ -98,7 +98,7 @@ if __name__ == '__main__':
 
     parser = argparse.ArgumentParser(description='Aggregates a metric or metrics for multiple HUC8s.')
     parser.add_argument('-c','--config',help='Save outputs to development_versions or previous_versions? Options: "DEV" or "PREV"',required=False)
-    parser.add_argument('-b','--branch-list',help='Name of branch to check all test_cases for and to aggregate.',required=True)
+    parser.add_argument('-b','--branch',help='Name of branch to check all test_cases for and to aggregate.',required=True)
     parser.add_argument('-u','--hucs',help='HUC8s to restrict the aggregation.',required=False, default="")
     parser.add_argument('-s','--special_string',help='Special string to add to outputs.',required=False, default="")
     parser.add_argument('-f','--outfolder',help='output folder',required=True,type=str)

--- a/tests/synthesize_test_cases.py
+++ b/tests/synthesize_test_cases.py
@@ -71,10 +71,10 @@ if __name__ == '__main__':
         
     procs_list = []
     for test_id in test_cases_dir_list:
-        if 'validation' and 'other' not in test_id:
+        if not any(x in test_id for x in ['validation','other','.lst']):#if 'validation' and 'other' not in test_id:
                         
             current_huc = test_id.split('_')[0]
-            
+            print(current_huc)
             if test_id.split('_')[1] in benchmark_category:
             
                 


### PR DESCRIPTION
Currently producing unwanted inundation outputs over ocean water areas. This is primarily due to the NHD DEM extent extending into the ocean. This feature branch uses a ocean/sea polygon to clip the REM output in run_by_unit.sh. 

Addresses issue #16
Addresses issue #124 


## Additions & Changes
### Input Data
Download the water polygons layer from OpenStreetMap database
Optional: clip to US domain to reduce file size
Data in input directory here: /inputs/landsea/
### snap_and_clip_to_nhd.py
Mask the landsea polygon to HUC wbd_buffer domain
### fim_run.sh
New steps:
gdal_raster → rasterize the landsea_subset features (value = $ndv for water pixels & 1 for everywhere else)
gdal_calc → multiply existing rem_zeroed_masked.tif by new landsea_subset.tif to keep only land pixels
This overwrites the rem_zero_mask.tif (includes the previous catchment mask)

### params_calibrated.env & params_template.env
Added the lake buffer distance variable as an argument for split_flows.py

### synthesize_test_cases.py & aggregate_metrics.py
A couple of minor bug fixes

## Metrics

 **No changes to FR aggregated evaluation metrics** (using huc list: dev_fim_ble_13020101.lst & the default Manning's value input). 

Comparing dev_oceanfim_fr_aggregate_metrics to dev_lakefim_fr_aggregate_metrics
- 100yr CSI: 0.55707
- 500yr CSI: 0.58335

## Recommended Testing
Run for a coastal HUC and visually check the output (rem_zeroed_masked.tiff). Non-nan REM values should be limited to land areas.

## Screenshots
![water_poly_overview](https://user-images.githubusercontent.com/69868854/101398094-324a2500-3893-11eb-9b76-3ef0f9b9a951.png)
![results_02030202_compare](https://user-images.githubusercontent.com/69868854/101397020-be5b4d00-3891-11eb-8bcf-f9e4b6eb1940.png)
![results_02030202](https://user-images.githubusercontent.com/69868854/101396138-83a4e500-3890-11eb-831c-ac71d8d4b4c7.png)
![results_03130013](https://user-images.githubusercontent.com/69868854/101398344-8e14ae00-3893-11eb-8648-ff9f9a8af75d.png)



