### PR TITLE
Updates to preprocessing scripts and remove incomplete output folders

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Flood inundation mapping software configured to work with the U.S. National Wate
 ## Configuration
 
 Software is configurable via parameters found in config directory. Copy files before editing and remove "template" pattern from the filename.
-Make sure to set the config folder group to 'fim' recursively using the chown command. Each development version will include a calibrated parameter set of manning’s n values. 
+Make sure to set the config folder group to 'fim' recursively using the chown command. Each development version will include a calibrated parameter set of manning’s n values.
 - params_template.env
 - mannings_default.json
     - must change filepath in params_template.env under "manning_n" variable name
@@ -51,14 +51,14 @@ NOTE: Some of the input data is not easy to acquire and will need to be shared w
     - `-u` can be a single HUC4, series of HUC4s (e.g. 1209 1210), path to line-delimited file with HUC4s.
     - Please run `/foss_fim/lib/acquire_and_preprocess_inputs.py --help` for more information.
     - See United States Geological Survey (USGS) National Hydrography Dataset Plus High Resolution (NHDPlusHR) [site](https://www.usgs.gov/core-science-systems/ngp/national-hydrography/nhdplus-high-resolution) for more information
-3. Aggregate NHD HR streams : /foss_fim/lib/aggregate_nhd_hr_streams.py
+3. Aggregate NHD HR streams and create NWM headwater points : /foss_fim/lib/aggregate_vector_inputs.py
 4. Produce Hydrofabric : `fim_run.sh -u <huc4,6,or8s> -c /foss_fim/config/<your_params_file.env> -n <name_your_run>`
     - `-u` can be a single huc, a series passed in quotes, or a line-delimited file
         i. To run entire domain of available data use one of the `/data/inputs/included_huc[4,6,8].lst` files
     - Outputs can be found under `/data/outputs/<name_your_run>`
 
 ## Evaluate FIM output to a Benchmark Dataset
-Once the hydrofabric has been generated from fim_run.sh for, evaluation against a benchmark dataset can be performed using binary contingency statistics. One benchmark dataset that can be used for evaluations are Base Level Engineering studies available on the FEMA Base Flood Elevation Viewer. To acquire FEMA datasets go to the FEMA Base Flood Elevation Viewer (https://webapps.usgs.gov/infrm/estbfe/) and download the file geodatabase and depth grids for a HUC. To perform an evaluation a flow forecast file is required and benchmark grids are preprocessed prior to running run_test_case.py. 
+Once the hydrofabric has been generated from fim_run.sh for, evaluation against a benchmark dataset can be performed using binary contingency statistics. One benchmark dataset that can be used for evaluations are Base Level Engineering studies available on the FEMA Base Flood Elevation Viewer. To acquire FEMA datasets go to the FEMA Base Flood Elevation Viewer (https://webapps.usgs.gov/infrm/estbfe/) and download the file geodatabase and depth grids for a HUC. To perform an evaluation a flow forecast file is required and benchmark grids are preprocessed prior to running run_test_case.py.
 
 1. Flow Forecast File Creation
 `/foss_fim/tests/preprocess/create_flow_forecast_file.py -b <path to BLE geodatabase> -n <path to NWM geodatabase> -o <output directory> -xs <Cross Section layer name in BLE geodatabase> -hu <HUC layer name in BLE geodatabase> -huid <HUC ID field in HUC layer> -l <Stream layer name in NWM geodatabase> -f <feature id field in stream layer of NWM geodatabase>`

--- a/config/params_calibrated.env
+++ b/config/params_calibrated.env
@@ -2,12 +2,14 @@
 
 #### geospatial parameters ####
 export negativeBurnValue=1000
+export buffer=70
 export maxSplitDistance_meters=1500
 export manning_n="/foss_fim/config/mannings_calibrated.json"
 export stage_min_meters=0
 export stage_interval_meters=0.3048
 export stage_max_meters=25
 export slope_min=0.001
+export ms_buffer_dist=7000
 
 #### computational parameters ####
 export ncores_gw=1 # mpi number of cores for gagewatershed

--- a/lib/acquire_and_preprocess_inputs.py
+++ b/lib/acquire_and_preprocess_inputs.py
@@ -275,7 +275,7 @@ def build_huc_list_files(path_to_saved_data_parent_dir, wbd_directory):
     included_huc6_file = os.path.join(path_to_saved_data_parent_dir, 'included_huc6.lst')
     included_huc8_file = os.path.join(path_to_saved_data_parent_dir, 'included_huc8.lst')
 
-        # Overly verbose file writing loops. Doing this in a pinch.
+    # Overly verbose file writing loops. Doing this in a pinch.
     with open(included_huc4_file, 'w') as f:
         for item in huc4_list:
             f.write("%s\n" % item)

--- a/lib/acquire_and_preprocess_inputs.py
+++ b/lib/acquire_and_preprocess_inputs.py
@@ -17,57 +17,57 @@ from utils.shared_variables import (NHD_URL_PARENT,
                                     NHD_VECTOR_EXTRACTION_SUFFIX,
                                     PREP_PROJECTION,
                                     WBD_NATIONAL_URL,
-                                    FOSS_ID, 
+                                    FOSS_ID,
                                     OVERWRITE_WBD,
                                     OVERWRITE_NHD,
                                     OVERWRITE_ALL)
 
 from utils.shared_functions import pull_file, run_system_command, subset_wbd_gpkg, delete_file
-    
+
 NHDPLUS_VECTORS_DIRNAME = 'nhdplus_vectors'
 NHDPLUS_RASTERS_DIRNAME = 'nhdplus_rasters'
 NWM_HYDROFABRIC_DIRNAME = 'nwm_hydrofabric'
 NWM_FILE_TO_SUBSET_WITH = 'nwm_flows.gpkg'
 
 def subset_wbd_to_nwm_domain(wbd,nwm_file_to_use):
-    
+
     intersecting_indices = [not (gp.read_file(nwm_file_to_use,mask=b).empty) for b in wbd.geometry]
-    
+
     return(wbd[intersecting_indices])
 
 def pull_and_prepare_wbd(path_to_saved_data_parent_dir,nwm_dir_name,nwm_file_to_use,overwrite_wbd,num_workers):
     """
     This helper function pulls and unzips Watershed Boundary Dataset (WBD) data. It uses the WBD URL defined by WBD_NATIONAL_URL.
     This function also subsets the WBD layers (HU4, HU6, HU8) to CONUS and converts to geopkacage layers.
-    
+
     Args:
         path_to_saved_data_parent_dir (str): The system path to where the WBD will be downloaded, unzipped, and preprocessed.
-    
+
     """
-    
+
     # Construct path to wbd_directory and create if not existent.
     wbd_directory = os.path.join(path_to_saved_data_parent_dir, 'wbd')
     if not os.path.exists(wbd_directory):
         os.mkdir(wbd_directory)
-    
+
     wbd_gdb_path = os.path.join(wbd_directory, 'WBD_National_GDB.gdb')
     pulled_wbd_zipped_path = os.path.join(wbd_directory, 'WBD_National_GDB.zip')
-            
+
     multilayer_wbd_geopackage = os.path.join(wbd_directory, 'WBD_National.gpkg')
-    
+
     nwm_huc_list_file_template = os.path.join(wbd_directory,'nwm_wbd{}.csv')
 
     nwm_file_to_use = os.path.join(path_to_saved_data_parent_dir,nwm_dir_name,nwm_file_to_use)
     if not os.path.isfile(nwm_file_to_use):
         raise IOError("NWM File to Subset Too Not Available: {}".format(nwm_file_to_use))
-    
+
     if not os.path.exists(multilayer_wbd_geopackage) or overwrite_wbd:
         # Download WBD and unzip if it's not already done.
         if not os.path.exists(wbd_gdb_path):
             if not os.path.exists(pulled_wbd_zipped_path):
                 pull_file(WBD_NATIONAL_URL, pulled_wbd_zipped_path)
             os.system("7za x {pulled_wbd_zipped_path} -o{wbd_directory}".format(pulled_wbd_zipped_path=pulled_wbd_zipped_path, wbd_directory=wbd_directory))
-        
+
         procs_list, wbd_gpkg_list = [], []
         multilayer_wbd_geopackage = os.path.join(wbd_directory, 'WBD_National.gpkg')
         # Add fossid to HU8, project, and convert to geopackage. Code block from Brian Avant.
@@ -103,36 +103,35 @@ def pull_and_prepare_wbd(path_to_saved_data_parent_dir,nwm_dir_name,nwm_file_to_
             #output_gpkg = os.path.join(wbd_directory, wbd_layer + '.gpkg')
             #wbd_gpkg_list.append(output_gpkg)
             #procs_list.append(['ogr2ogr -overwrite -progress -f GPKG -t_srs "{projection}" {output_gpkg} {wbd_gdb_path} {wbd_layer}'.format(output_gpkg=output_gpkg, wbd_gdb_path=wbd_gdb_path, wbd_layer=wbd_layer, projection=PREP_PROJECTION)])
-       
+
         #pool = Pool(num_workers)
         #pool.map(run_system_command, procs_list)
-        
+
         # Subset WBD layers to CONUS and add to single geopackage.
         #print("Subsetting WBD layers to CONUS...")
         #multilayer_wbd_geopackage = os.path.join(wbd_directory, 'WBD_National.gpkg')
         #for gpkg in wbd_gpkg_list:
         #    subset_wbd_gpkg(gpkg, multilayer_wbd_geopackage)
-        
+
     # Clean up temporary files.
     #for temp_layer in ['WBDHU4', 'WBDHU6', 'WBDHU8']:
     #    delete_file(os.path.join(wbd_directory, temp_layer + '.gpkg'))
     #pulled_wbd_zipped_path = os.path.join(wbd_directory, 'WBD_National_GDB.zip')
     #delete_file(pulled_wbd_zipped_path)
-    #delete_file(os.path.join(wbd_directory, 'WBD_National_GDB.jpg'))    
+    #delete_file(os.path.join(wbd_directory, 'WBD_National_GDB.jpg'))
 
     return(wbd_directory)
-            
 
 def pull_and_prepare_nwm_hydrofabric(path_to_saved_data_parent_dir, path_to_preinputs_dir,num_workers):
     """
     This helper function pulls and unzips NWM hydrofabric data. It uses the NWM hydrofabric URL defined by NWM_HYDROFABRIC_URL.
-    
+
     Args:
         path_to_saved_data_parent_dir (str): The system path to where a 'nwm' subdirectory will be created and where NWM hydrofabric
         will be downloaded, unzipped, and preprocessed.
-        
+
     """
-    
+
     # -- Acquire and preprocess NWM data -- #
     nwm_hydrofabric_directory = os.path.join(path_to_saved_data_parent_dir, 'nwm_hydrofabric')
     if not os.path.exists(nwm_hydrofabric_directory):
@@ -146,45 +145,45 @@ def pull_and_prepare_nwm_hydrofabric(path_to_saved_data_parent_dir, path_to_prei
     for nwm_layer in ['nwm_flows', 'nwm_lakes', 'nwm_catchments']:  # I had to project the catchments and waterbodies because these 3 layers had varying CRSs.
         print("Operating on " + nwm_layer)
         output_gpkg = os.path.join(nwm_hydrofabric_directory, nwm_layer + '_proj.gpkg')
-        procs_list.append(['ogr2ogr -overwrite -progress -f GPKG -t_srs "{projection}" {output_gpkg} {nwm_hydrofabric_gdb} {nwm_layer}'.format(projection=PREP_PROJECTION, output_gpkg=output_gpkg, nwm_hydrofabric_gdb=nwm_hydrofabric_gdb, nwm_layer=nwm_layer)])        
-        
+        procs_list.append(['ogr2ogr -overwrite -progress -f GPKG -t_srs "{projection}" {output_gpkg} {nwm_hydrofabric_gdb} {nwm_layer}'.format(projection=PREP_PROJECTION, output_gpkg=output_gpkg, nwm_hydrofabric_gdb=nwm_hydrofabric_gdb, nwm_layer=nwm_layer)])
+
     pool = Pool(num_workers)
     pool.map(run_system_command, procs_list)
     pool.close()
-        
+
 
 def pull_and_prepare_nhd_data(args):
     """
     This helper function is designed to be multiprocessed. It pulls and unzips NHD raster and vector data.
-    
     Args:
         args (list): A list of arguments in this format: [nhd_raster_download_url, nhd_raster_extraction_path, nhd_vector_download_url, nhd_vector_extraction_path]
-        
     """
-    
     # Parse urls and extraction paths from procs_list.
     nhd_raster_download_url = args[0]
     nhd_raster_extraction_path = args[1]
     nhd_vector_download_url = args[2]
     nhd_vector_extraction_path = args[3]
     overwrite_nhd = args[4]
-    
-    nhd_gdb = nhd_vector_extraction_path.replace('.zip', '.gdb')  # Update extraction path from .zip to .gdb. 
+
+    nhd_gdb = nhd_vector_extraction_path.replace('.zip', '.gdb')  # Update extraction path from .zip to .gdb.
 
     # Download raster and vector, if not already in user's directory (exist check performed by pull_file()).
     nhd_raster_extraction_parent = os.path.dirname(nhd_raster_extraction_path)
-    
-    huc = nhd_raster_extraction_path.split('_')[3]
-    nhd_raster_parent_dir = os.path.join(nhd_raster_extraction_parent, 'HRNHDPlusRasters' + huc)
-    elev_cm_tif = os.path.join(nhd_raster_parent_dir, 'elev_cm.tif')
+    huc = os.path.basename(nhd_raster_extraction_path).split('_')[2]
+    print(str(huc))
 
+    nhd_raster_parent_dir = os.path.join(nhd_raster_extraction_parent, 'HRNHDPlusRasters' + huc)
+
+    if not os.path.exists(nhd_raster_parent_dir):
+        os.mkdir(nhd_raster_parent_dir)
+
+    elev_cm_tif = os.path.join(nhd_raster_parent_dir, 'elev_cm.tif')
     if not os.path.exists(elev_cm_tif) or overwrite_nhd:
         pull_file(nhd_raster_download_url, nhd_raster_extraction_path)
         os.system("7za e {nhd_raster_extraction_path} -o{nhd_raster_parent_dir} elev_cm.tif -r ".format(nhd_raster_extraction_path=nhd_raster_extraction_path, nhd_raster_parent_dir=nhd_raster_parent_dir))
         # Change projection for elev_cm.tif.
         #print("Projecting elev_cm...")
         #run_system_command(['gdal_edit.py -a_srs "{projection}" {elev_cm_tif}'.format(projection=PREP_PROJECTION, elev_cm_tif=elev_cm_tif)])
-                
         file_list = os.listdir(nhd_raster_parent_dir)
         for f in file_list:
             full_path = os.path.join(nhd_raster_parent_dir, f)
@@ -193,117 +192,134 @@ def pull_and_prepare_nhd_data(args):
                     shutil.rmtree(full_path)
                 elif os.path.isfile(full_path):
                     os.remove(full_path)
-        os.remove(nhd_raster_extraction_path)
-        
+        # os.remove(nhd_raster_extraction_path)
     nhd_vector_extraction_parent = os.path.dirname(nhd_vector_extraction_path)
+
+    if not os.path.exists(nhd_vector_extraction_parent):
+        os.mkdir(nhd_vector_extraction_parent)
+
     if not os.path.exists(nhd_gdb) or overwrite_nhd:  # Only pull if not already pulled and processed.
         # Download and fully unzip downloaded GDB.
         pull_file(nhd_vector_download_url, nhd_vector_extraction_path)
         huc = os.path.split(nhd_vector_extraction_parent)[1]  # Parse HUC.
         os.system("7za x {nhd_vector_extraction_path} -o{nhd_vector_extraction_parent}".format(nhd_vector_extraction_path=nhd_vector_extraction_path, nhd_vector_extraction_parent=nhd_vector_extraction_parent))
-        
+        # extract input stream network
         nhd = gp.read_file(nhd_gdb,layer='NHDPlusBurnLineEvent')
         nhd = nhd.to_crs(PREP_PROJECTION)
         nhd.to_file(os.path.join(nhd_vector_extraction_parent, 'NHDPlusBurnLineEvent' + huc + '.gpkg'),driver='GPKG')
-        
+        # extract flowlines for FType attributes
+        nhd = gp.read_file(nhd_gdb,layer='NHDFlowline')
+        nhd = nhd.to_crs(PREP_PROJECTION)
+        nhd.to_file(os.path.join(nhd_vector_extraction_parent, 'NHDFlowline' + huc + '.gpkg'),driver='GPKG')
+        # extract sea boundaries for exclusion
+        nhd = gp.read_file(nhd_gdb,layer='NHDPlusLandSea')
+        if len(nhd) > 0:
+            nhd = nhd.to_crs(PREP_PROJECTION)
+            nhd.to_file(os.path.join(nhd_vector_extraction_parent, 'NHDPlusLandSea' + huc + '.gpkg'),driver='GPKG')
+        # extract waterbodies for FType attributes
+        nhd = gp.read_file(nhd_gdb,layer='NHDPlusBurnWaterbody')
+        nhd = nhd.to_crs(PREP_PROJECTION)
+        nhd.to_file(os.path.join(nhd_vector_extraction_parent, 'NHDPlusBurnWaterbody' + huc + '.gpkg'),driver='GPKG')
+        # extract attributes
         nhd = gp.read_file(nhd_gdb,layer='NHDPlusFlowLineVAA')
         nhd.to_file(os.path.join(nhd_vector_extraction_parent, 'NHDPlusFlowLineVAA' + huc + '.gpkg'),driver='GPKG')
-        
         # -- Project and convert NHDPlusBurnLineEvent and NHDPlusFlowLineVAA vectors to geopackage -- #
         #for nhd_layer in ['NHDPlusBurnLineEvent', 'NHDPlusFlowlineVAA']:
         #    run_system_command(['ogr2ogr -overwrite -progress -f GPKG -t_srs "{projection}" {output_gpkg} {nhd_gdb} {nhd_layer}'.format(projection=PREP_PROJECTION, output_gpkg=output_gpkg, nhd_gdb=nhd_gdb, nhd_layer=nhd_layer)])  # Use list because function is configured for multiprocessing.
-
     # Delete unnecessary files.
     delete_file(nhd_vector_extraction_path.replace('.zip', '.jpg'))
     delete_file(nhd_vector_extraction_path)  # Delete the zipped GDB.
-    
-    
+
+
 def build_huc_list_files(path_to_saved_data_parent_dir, wbd_directory):
     """
     This function builds a list of available HUC4s, HUC6s, and HUC8s and saves the lists to .lst files.
-    
+
     Args:
         path_to_saved_data_parent_dir (str): The path to the parent directory where the .lst files will be saved.
         wbd_directory (str): The path to the directory storing the WBD geopackages which are used to determine which HUCs are available for processing.
-    
+
     """
-    
+
     print("Building included HUC lists...")
     # Identify all saved NHDPlus Vectors.
-    nhd_plus_vector_dir = os.path.join(path_to_saved_data_parent_dir, NHDPLUS_RASTERS_DIRNAME)
-    
-    huc4_list = [i[-4:] for i in os.listdir(nhd_plus_vector_dir)]
-        
+    nhd_plus_raster_dir = os.path.join(path_to_saved_data_parent_dir, NHDPLUS_RASTERS_DIRNAME)
+    nhd_plus_vector_dir = os.path.join(path_to_saved_data_parent_dir, NHDPLUS_VECTORS_DIRNAME)
+
+    huc4_list = [i[-4:] for i in os.listdir(nhd_plus_raster_dir)]
+
     huc6_list, huc8_list = [], []
+
     # Read WBD into dataframe.
-    
-    huc_gpkg_list = ['WBDHU6', 'WBDHU8']  # The WBDHU4 are handled by the nhd_plus_vector_dir name.
-    
-    for huc_gpkg in huc_gpkg_list:
-        full_huc_gpkg = os.path.join(wbd_directory, 'WBD_National.gpkg')
-    
-        # Open geopackage.
-        wbd = gp.read_file(full_huc_gpkg, layer=huc_gpkg)
-        gdf = gp.GeoDataFrame(wbd)
-        
-        # Loop through entries and compare against the huc4_list to get available HUCs within the geopackage domain.
-        for index, row in gdf.iterrows():
-            huc = row["HUC" + huc_gpkg[-1]]
-            
-            # Append huc to appropriate list.
-            if str(huc[:4]) in huc4_list:
-                if huc_gpkg == 'WBDHU6':
-                    huc6_list.append(huc)
-                elif huc_gpkg == 'WBDHU8':
-                    huc8_list.append(huc)       
-    
+    # huc_gpkg_list = ['WBDHU6', 'WBDHU8']  # The WBDHU4 are handled by the nhd_plus_raster_dir name.
+    full_huc_gpkg = os.path.join(wbd_directory, 'WBD_National.gpkg')
+    huc_gpkg = 'WBDHU8'
+
+    # Open geopackage.
+    # wbd = gp.read_file(full_huc_gpkg, layer=huc_gpkg)
+    wbd = gp.read_file(full_huc_gpkg, layer='WBDHU8')
+
+    # Loop through entries and compare against the huc4_list to get available HUCs within the geopackage domain.
+for index, row in tqdm(wbd.iterrows()):
+    huc = row["HUC" + huc_gpkg[-1]]
+    huc_mask = wbd.loc[wbd[str("HUC" + huc_gpkg[-1])]==huc].geometry
+    burnline = os.path.join(nhd_plus_vector_dir, huc[0:4], 'NHDPlusBurnLineEvent' + huc[0:4] + '.gpkg')
+    if os.path.exists(burnline):
+        nhd_test = len(gp.read_file(burnline, mask = huc_mask)) # this is slow, iterates through 2000+ HUC8s
+        # Append huc to appropriate list.
+        if (str(huc[:4]) in huc4_list) & (nhd_test>0):
+            huc8_list.append(huc)
+
+    huc6_list = [w[:6] for w in huc8_list]
+    huc6_list = set(huc6_list)
+
     # Write huc lists to appropriate .lst files.
     included_huc4_file = os.path.join(path_to_saved_data_parent_dir, 'included_huc4.lst')
     included_huc6_file = os.path.join(path_to_saved_data_parent_dir, 'included_huc6.lst')
     included_huc8_file = os.path.join(path_to_saved_data_parent_dir, 'included_huc8.lst')
-    
-    # Overly verbose file writing loops. Doing this in a pinch.
+
+        # Overly verbose file writing loops. Doing this in a pinch.
     with open(included_huc4_file, 'w') as f:
         for item in huc4_list:
             f.write("%s\n" % item)
-            
+
     with open(included_huc6_file, 'w') as f:
         for item in huc6_list:
             f.write("%s\n" % item)
-            
+
     with open(included_huc8_file, 'w') as f:
         for item in huc8_list:
             f.write("%s\n" % item)
-    
-    
+
+
 def manage_preprocessing(hucs_of_interest, num_workers=1,overwrite_nhd=False, overwrite_wbd=False):
     """
     This functions manages the downloading and preprocessing of gridded and vector data for FIM production.
-    
+
     Args:
         hucs_of_interest (str): Path to a user-supplied config file of hydrologic unit codes to be pulled and post-processed.
-        
+
     """
 
     #get input data dir
     path_to_saved_data_parent_dir = os.environ['inputDataDir']
 
     nhd_procs_list = []  # Initialize procs_list for multiprocessing.
-    
+
     # Create the parent directory if nonexistent.
     if not os.path.exists(path_to_saved_data_parent_dir):
         os.mkdir(path_to_saved_data_parent_dir)
-        
+
     # Create NHDPlus raster parent directory if nonexistent.
     nhd_raster_dir = os.path.join(path_to_saved_data_parent_dir, NHDPLUS_RASTERS_DIRNAME)
     if not os.path.exists(nhd_raster_dir):
         os.mkdir(nhd_raster_dir)
-        
+
     # Create the vector data parent directory if nonexistent.
     vector_data_dir = os.path.join(path_to_saved_data_parent_dir, NHDPLUS_VECTORS_DIRNAME)
     if not os.path.exists(vector_data_dir):
         os.mkdir(vector_data_dir)
-    
+
     # Parse HUCs from hucs_of_interest.
     if isinstance(hucs_of_interest,list):
         if len(hucs_of_interest) == 1:
@@ -320,16 +336,16 @@ def manage_preprocessing(hucs_of_interest, num_workers=1,overwrite_nhd=False, ov
                 huc_list = [i[0] for i in csv.reader(csv_file)]
         except FileNotFoundError:
             huc_list = list(hucs_of_interest)
-    
-        
+
+
     # Construct paths to data to download and append to procs_list for multiprocessed pull, project, and converstion to geopackage.
     for huc in huc_list:
         huc = str(huc)  # Ensure huc is string.
-    
+
         # Construct URL and extraction path for NHDPlus raster.
         nhd_raster_download_url = os.path.join(NHD_URL_PARENT, NHD_URL_PREFIX + huc + NHD_RASTER_URL_SUFFIX)
         nhd_raster_extraction_path = os.path.join(nhd_raster_dir, NHD_URL_PREFIX + huc + NHD_RASTER_URL_SUFFIX)
-        
+
         # Construct URL and extraction path for NHDPlus vector. Organize into huc-level subdirectories.
         nhd_vector_download_url = os.path.join(NHD_URL_PARENT, NHD_URL_PREFIX + huc + NHD_VECTOR_URL_SUFFIX)
         nhd_vector_download_parent = os.path.join(vector_data_dir, huc)
@@ -339,7 +355,7 @@ def manage_preprocessing(hucs_of_interest, num_workers=1,overwrite_nhd=False, ov
 
         # Append extraction instructions to nhd_procs_list.
         nhd_procs_list.append([nhd_raster_download_url, nhd_raster_extraction_path, nhd_vector_download_url, nhd_vector_extraction_path, overwrite_nhd])
-        
+
     # Pull and prepare NHD data.
     #pool = Pool(num_workers)
     #pool.map(pull_and_prepare_nhd_data, nhd_procs_list)
@@ -348,28 +364,27 @@ def manage_preprocessing(hucs_of_interest, num_workers=1,overwrite_nhd=False, ov
             pull_and_prepare_nhd_data(huc)
         except HTTPError:
             print("404 error for HUC4 {}".format(huc))
-    
+
     # Pull and prepare NWM data.
     #pull_and_prepare_nwm_hydrofabric(path_to_saved_data_parent_dir, path_to_preinputs_dir,num_workers)  # Commented out for now.
 
     # Pull and prepare WBD data.
-    wbd_directory = pull_and_prepare_wbd(path_to_saved_data_parent_dir,NWM_HYDROFABRIC_DIRNAME,NWM_FILE_TO_SUBSET_WITH,overwrite_wbd,num_workers)
-    
+    # wbd_directory = pull_and_prepare_wbd(path_to_saved_data_parent_dir,NWM_HYDROFABRIC_DIRNAME,NWM_FILE_TO_SUBSET_WITH,overwrite_wbd,num_workers)
+
     # Create HUC list files.
-    build_huc_list_files(path_to_saved_data_parent_dir, wbd_directory)
+    # build_huc_list_files(path_to_saved_data_parent_dir, wbd_directory)
 
 
 if __name__ == '__main__':
-    
+
     # Parse arguments.
     parser = argparse.ArgumentParser(description='Acquires and preprocesses WBD and NHD data for use in fim_run.sh.')
     parser.add_argument('-u','--hucs-of-interest',help='HUC4, series of HUC4s, or path to a line-delimited file of HUC4s to acquire.',required=True,nargs='+')
     #parser.add_argument('-j','--num-workers',help='Number of workers to process with',required=False,default=1,type=int)
     parser.add_argument('-n', '--overwrite-nhd', help='Optional flag to overwrite NHDPlus Data',required=False,action='store_true')
     parser.add_argument('-w', '--overwrite-wbd', help='Optional flag to overwrite WBD Data',required=False,action='store_true')
-    
+
     # Extract to dictionary and assign to variables.
     args = vars(parser.parse_args())
-    
+
     manage_preprocessing(**args)
-            

--- a/lib/aggregate_vector_inputs.py
+++ b/lib/aggregate_vector_inputs.py
@@ -6,6 +6,7 @@ import pandas as pd
 from os.path import splitext
 from utils.shared_variables import PREP_PROJECTION
 from derive_headwaters import findHeadWaterPoints
+from tqdm import tqdm
 
 in_dir ='data/inputs/nhdplus_vectors'
 nhd_dir ='data/inputs/nhdplus_vectors_aggregate'
@@ -19,24 +20,28 @@ nwm_headwaters.to_file(os.path.join(nwm_dir,'nwm_headwaters.gpkg'),driver='GPKG'
 
 ## NHDPlus HR
 print ('aggregating NHDPlus HR burnline layers')
-nhd_streams_wVAA_fileName_pre=os.path.join(nhd_dir,'NHDPlusBurnLineEvent_wVAA.gpkg')
+nhd_streams_wVAA_fileName_pre=os.path.join(nhd_dir,'NHDPlusBurnLineEvent_wVAA_fcode.gpkg')
 
 schema = {'geometry': 'MultiLineString','properties': {'NHDPlusID': 'str','ReachCode': 'str',
                                                   'FromNode': 'str','ToNode': 'str',
                                                   'StreamOrde': 'str','DnLevelPat': 'str',
                                                   'LevelPathI': 'str'}}
-                                                  
-for huc in os.listdir(in_dir):
+
+for huc in tqdm(os.listdir(in_dir)):
     if not huc[0]=='#':
         burnline_filename = os.path.join(in_dir,huc,'NHDPlusBurnLineEvent' + str(huc) + '.gpkg')
         vaa_filename = os.path.join(in_dir,huc,'NHDPlusFlowLineVAA' + str(huc) + '.gpkg')
+        flowline_filename = os.path.join(in_dir,huc,'NHDFlowline' + str(huc) + '.gpkg')
         if os.path.exists(os.path.join(in_dir,huc,'NHDPlusBurnLineEvent' + str(huc) + '.gpkg')):
             burnline = gpd.read_file(burnline_filename)
             nhd_streams_vaa = gpd.read_file(vaa_filename)
+            flowline = gpd.read_file(flowline_filename)
             burnline = burnline[['NHDPlusID','ReachCode','geometry']]
+            flowline = flowline[['NHDPlusID','FCode']]
             nhd_streams_vaa = nhd_streams_vaa[['FromNode','ToNode','NHDPlusID','StreamOrde','DnLevelPat','LevelPathI']]
             nhd_streams_withVAA = burnline.merge(nhd_streams_vaa,on='NHDPlusID',how='inner')
-            nhd_streams = nhd_streams_withVAA.to_crs(PREP_PROJECTION)
+            nhd_streams_fcode = nhd_streams_withVAA.merge(flowline,on='NHDPlusID',how='inner')
+            nhd_streams = nhd_streams_fcode.to_crs(PREP_PROJECTION)
             if os.path.isfile(nhd_streams_wVAA_fileName_pre):
                 nhd_streams.to_file(nhd_streams_wVAA_fileName_pre,driver='GPKG',index=False, mode='a')
             else:

--- a/lib/aggregate_vector_inputs.py
+++ b/lib/aggregate_vector_inputs.py
@@ -20,7 +20,7 @@ nwm_headwaters.to_file(os.path.join(nwm_dir,'nwm_headwaters.gpkg'),driver='GPKG'
 
 ## NHDPlus HR
 print ('aggregating NHDPlus HR burnline layers')
-nhd_streams_wVAA_fileName_pre=os.path.join(nhd_dir,'NHDPlusBurnLineEvent_wVAA_fcode.gpkg')
+nhd_streams_wVAA_fileName_pre=os.path.join(nhd_dir,'NHDPlusBurnLineEvent_wVAA.gpkg')
 
 schema = {'geometry': 'MultiLineString','properties': {'NHDPlusID': 'str','ReachCode': 'str',
                                                   'FromNode': 'str','ToNode': 'str',

--- a/lib/run_by_unit.sh
+++ b/lib/run_by_unit.sh
@@ -58,6 +58,7 @@ Tcount
 if [ "$extent" = "MS" ]; then
   if [[ ! -f $outputHucDataDir/NHDPlusBurnLineEvent_subset.gpkg ]] ; then
     echo "No AHPs point(s) within HUC $hucNumber boundaries. Aborting run_by_unit.sh"
+    rm -rf $outputHucDataDir
     exit 0
   fi
 fi
@@ -246,6 +247,7 @@ if [ "$extent" = "MS" ]; then
 
   if [[ ! -f $outputHucDataDir/dem_thalwegCond_MS.tif ]] ; then
     echo "No AHPs point(s) within HUC $hucNumber boundaries. Aborting run_by_unit.sh"
+    rm -rf $outputHucDataDir
     exit 0
   fi
 
@@ -325,6 +327,7 @@ $libDir/filter_catchments_and_add_attributes.py $outputHucDataDir/gw_catchments_
 
 if [[ ! -f $outputHucDataDir/gw_catchments_reaches_filtered_addedAttributes.gpkg ]] ; then
   echo "No relevant streams within HUC $hucNumber boundaries. Aborting run_by_unit.sh"
+  rm -rf $outputHucDataDir
   exit 0
 fi
 Tcount


### PR DESCRIPTION
Update preprocessing scripts and remove incomplete output folders.

## Issues Resolved
- #39 
- #138
- partial resolution of #118 

## Changes

- added 20+ HUC4s to inputs and updated all HUCs to latest version
- updates params_calibrated.env parameters
- run_by_unit.sh now removes HUC folders that do not produce FIMs
- aggregate_vector_inputs.py merges 'FCode' attribute from NHDPlus HR Flowline layer with NHDPlusBurnLineEvent layer
- acquire_and_preprocess_inputs.py extracts new vector layers (NHDFlowline, NHDPlusLandSea, and NHDPlusBurnWaterbody) and limits included HUC lists to HUCs that contain stream segments