### PR TITLE
Fixed issue with leading zeros in Viz Post Processing

### DIFF
--- a/lib/output_cleanup.py
+++ b/lib/output_cleanup.py
@@ -58,8 +58,8 @@ def output_cleanup(huc_number, output_folder_path, additional_whitelist, is_prod
         with open(os.path.join(output_folder_path, 'hydroTable.csv')) as csvf: 
             csvReader = csv.DictReader(csvf) 
             for row in csvReader: 
-                if row['HydroID'] in src_data and 'nwm_feature_id' not in src_data[row['HydroID']]:
-                    src_data[row['HydroID']]['nwm_feature_id'] = row['feature_id']
+                if row['HydroID'].lstrip('0') in src_data and 'nwm_feature_id' not in src_data[row['HydroID'].lstrip('0')]:
+                    src_data[row['HydroID'].lstrip('0')]['nwm_feature_id'] = row['feature_id']
 
         # Write src_data to JSON file
         with open(os.path.join(output_folder_path, f'rating_curves_{huc_number}.json'), 'w') as jsonf: 


### PR DESCRIPTION
When extracting the feature_ids from the `hydroTable.csv` and adding them to the `src.json`, as per Viz's output requirements, there was an issue with HydroIDs having leading zeros in the `hydroTable.csv`, but not in the `src.json`.

This was fixed by stripping the leading zeros from the HydroIDs in the `hydroTable.csv` when comparing them to the `src.json`.

With this fixed, when using the `-v` parameter, the `rating_curves_<HUD_ID>.json` should now correctly have the `nwm_feature_id` property added to each HydroID.

This fix only affects the `-v` post-processing parameter and does not affect any metrics regarding the fim output.

Some good test hucs that have HydroIDs with leading zeros are:

 - 030201
 - 060101
 - 080402