### PR TITLE
[1pt] PR: Fix for >0 no data values & masking Great Lakes water bodies

### DIFF
--- a/lib/run_by_unit.sh
+++ b/lib/run_by_unit.sh
@@ -90,11 +90,6 @@ echo -e $startDiv"Get DEM Metadata $hucNumber"$stopDiv
 date -u
 Tstart
 read fsize ncols nrows ndv xmin ymin xmax ymax cellsize_resx cellsize_resy<<<$($libDir/getRasterInfoNative.py $outputHucDataDir/dem.tif)
-if [[ ${ndv%%.*} -ge 0 ]] ; then
-	echo -e "$hucNumber raster NDV is >= 0 --> resetting to -2147483648"
-	ndv=-2147483648
-fi
-Tcount
 
 ## RASTERIZE NLD MULTILINES ##
 echo -e $startDiv"Rasterize all NLD multilines using zelev vertices"$stopDiv
@@ -318,7 +313,7 @@ echo -e $startDiv"Zero out negative values in distance down grid $hucNumber"$sto
 date -u
 Tstart
 [ ! -f $outputHucDataDir/rem_zeroed.tif ] && \
-gdal_calc.py --quiet --type=Float32 --overwrite --co "COMPRESS=LZW" --co "BIGTIFF=YES" --co "TILED=YES" -A $outputHucDataDir/rem.tif --calc="(A*(A>=0))+((A<=$ndv)*$ndv)" --NoDataValue=$ndv --outfile=$outputHucDataDir/"rem_zeroed.tif"
+gdal_calc.py --quiet --type=Float32 --overwrite --co "COMPRESS=LZW" --co "BIGTIFF=YES" --co "TILED=YES" -A $outputHucDataDir/rem.tif --calc="(A*(A>=0))" --NoDataValue=$ndv --outfile=$outputHucDataDir/"rem_zeroed.tif"
 Tcount
 
 ## POLYGONIZE REACH WATERSHEDS ##
@@ -359,7 +354,7 @@ gdal_rasterize -ot Int32 -a HydroID -a_nodata 0 -init 0 -co "COMPRESS=LZW" -co "
 Tcount
 
 ## RASTERIZE LANDSEA (OCEAN AREA) POLYGON (IF APPLICABLE) ##
-echo -e $startDiv"Rasterize filtered/dissolved ocean/glake polygon $hucNumber"$stopDiv
+echo -e $startDiv"Rasterize filtered/dissolved ocean/Glake polygon $hucNumber"$stopDiv
 date -u
 Tstart
 [ -f $outputHucDataDir/LandSea_subset.gpkg ] && [ ! -f $outputHucDataDir/LandSea_subset.tif ] && \
@@ -379,11 +374,11 @@ echo -e $startDiv"Masking REM Raster to HUC $hucNumber"$stopDiv
 date -u
 Tstart
 [ ! -f $outputHucDataDir/rem_zeroed_masked.tif ] && \
-gdal_calc.py --quiet --type=Float32 --overwrite --co "COMPRESS=LZW" --co "BIGTIFF=YES" --co "TILED=YES" -A $outputHucDataDir/rem_zeroed.tif -B $outputHucDataDir/gw_catchments_reaches_filtered_addedAttributes.tif --calc="(A*(B>0))+((B<=0)*$ndv)" --NoDataValue=$ndv --outfile=$outputHucDataDir/"rem_zeroed_masked.tif"
+gdal_calc.py --quiet --type=Float32 --overwrite --co "COMPRESS=LZW" --co "BIGTIFF=YES" --co "TILED=YES" -A $outputHucDataDir/rem_zeroed.tif -B $outputHucDataDir/gw_catchments_reaches_filtered_addedAttributes.tif --calc="(A*(B>0))" --NoDataValue=$ndv --outfile=$outputHucDataDir/"rem_zeroed_masked.tif"
 Tcount
 
 ## MASK REM RASTER TO REMOVE OCEAN AREAS ##
-echo -e $startDiv"Additional masking to REM raster to remove ocean/glake areas in HUC $hucNumber"$stopDiv
+echo -e $startDiv"Additional masking to REM raster to remove ocean/Glake areas in HUC $hucNumber"$stopDiv
 date -u
 Tstart
 [ -f $outputHucDataDir/LandSea_subset.tif ] && \

--- a/lib/run_by_unit.sh
+++ b/lib/run_by_unit.sh
@@ -91,8 +91,8 @@ date -u
 Tstart
 read fsize ncols nrows ndv xmin ymin xmax ymax cellsize_resx cellsize_resy<<<$($libDir/getRasterInfoNative.py $outputHucDataDir/dem.tif)
 if [[ ${ndv%%.*} -ge 0 ]] ; then
-	echo -e "$hucNumber raster NDV is >= 0 --> resetting to -9999"
-	ndv=-9999
+	echo -e "$hucNumber raster NDV is >= 0 --> resetting to -2147483648"
+	ndv=-2147483648
 fi
 Tcount
 

--- a/lib/snap_and_clip_to_nhd.py
+++ b/lib/snap_and_clip_to_nhd.py
@@ -20,7 +20,8 @@ def subset_vector_layers(hucCode,nwm_streams_fileName,nwm_headwaters_fileName,nh
     projection = wbd.crs
     
     # Clip ocean water polygon for future masking ocean areas (where applicable)
-    landsea = gpd.read_file(landsea_filename, mask = wbd_buffer)
+    landsea_read = gpd.read_file(landsea_filename, mask = wbd_buffer)
+    landsea = gpd.clip(landsea_read, wbd_buffer)
     if not landsea.empty:
         landsea.to_file(subset_landsea_filename,driver=getDriver(subset_landsea_filename),index=False)
     del landsea


### PR DESCRIPTION
Some of the raw NHDPlus DEMs in the Great Lakes region (e.g. 0402-0411) use large positive values to designate no data pixels (e.g. 65535). This causes issues in the gdal_calc formula used in the REM zeroed step. Incorporated previous fix for this issue from [commit 7e6339](https://github.com/NOAA-OWP/cahaba/commit/7e6339c27ef68b683b24ea8411c0016521aa29d1?branch=7e6339c27ef68b683b24ea8411c0016521aa29d1&diff=split). Future consideration: may want to set up a more robust catch in run_by_unit.sh or in the preprocessing workflow to reassign ndv to avoid potential issues with masking positive values.
Resolves issue #160  

Use a Great Lakes water body polygon to mask REM for HUC=04. Using gl_water_polygon.gpkg input. Applies the same methods as coastal/ocean masking. If statement checks if HUC=04 (Great Lakes) region and then assigns the landsea input file.
Resolves issue #153 

## Additions
### run_by_unit.sh
- new if statement to check which HUC2 and then assign either the Great Lakes polygon or coastal/ocean polygon for masking (input_LANDSEA)

### snap_and_clip_to_nhd.py
- added gdal.clip step to trim the landsea water polygon to the wbd_buffer boundary. This helps reduce the workflow's data footprint and processing time.

## Changes

- modified the gdal_calc equations --> removed `+((A<=$ndv)*$ndv)` in the rem_zeroed.tif and rem_zeroed_mask.tif generation
- also modified a couple of print/echo statements to reflect recent changes

## Testing

1. Suggest running a Great Lakes region huc (e.g. 0408) 


## Notes

- None of these changes should have any impact on the BLE evaluation metrics

## Screenshots
![ndv_problem](https://user-images.githubusercontent.com/69868854/102277474-f72c9f00-3eed-11eb-9960-d3fd2500d612.png)
![gl_mask_prob](https://user-images.githubusercontent.com/69868854/102278385-5b9c2e00-3eef-11eb-8d08-4ed6ed044531.png)
![gl_mask_prob2](https://user-images.githubusercontent.com/69868854/102277495-ff84da00-3eed-11eb-811e-32495184474e.png)
![final_results](https://user-images.githubusercontent.com/69868854/102278397-61920f00-3eef-11eb-8f16-97d6e2081b5a.png)

