### PR TITLE
PR: Error handling for empty stream network in coastal/lake hucs

### DIFF
--- a/lib/run_by_unit.sh
+++ b/lib/run_by_unit.sh
@@ -86,6 +86,11 @@ Tstart
 read fsize ncols nrows ndv xmin ymin xmax ymax cellsize_resx cellsize_resy<<<$($libDir/getRasterInfoNative.py $outputHucDataDir/dem.tif)
 Tcount
 
+echo $ndv
+if [ ${ndv%%.*} -ge 0 ]; then
+      $ndv=-9999
+fi
+
 ## RASTERIZE NLD POLYLINES ##
 echo -e $startDiv"Rasterize all NLD polylines using zelev vertices"$stopDiv
 date -u

--- a/lib/run_by_unit.sh
+++ b/lib/run_by_unit.sh
@@ -238,6 +238,12 @@ Tstart
 $libDir/split_flows.py $outputHucDataDir/demDerived_reaches.shp $outputHucDataDir/dem_thalwegCond.tif $outputHucDataDir/demDerived_reaches_split.gpkg $outputHucDataDir/demDerived_reaches_split_points.gpkg $maxSplitDistance_meters $slope_min $outputHucDataDir/wbd8_clp.gpkg $outputHucDataDir/nwm_lakes_proj_subset.gpkg $lakes_buffer_dist_meters
 Tcount
 
+if [[ ! -f $outputHucDataDir/demDerived_reaches_split.gpkg ]] ; then
+  echo "No AHPs point(s) within HUC $hucNumber boundaries. Aborting run_by_unit.sh"
+  # rm -rf $outputHucDataDir
+  exit 0
+fi
+
 if [ "$extent" = "MS" ]; then
   ## MASK RASTERS BY MS BUFFER ##
   echo -e $startDiv"Mask Rasters with Stream Buffer $hucNumber"$stopDiv

--- a/lib/run_by_unit.sh
+++ b/lib/run_by_unit.sh
@@ -86,11 +86,6 @@ Tstart
 read fsize ncols nrows ndv xmin ymin xmax ymax cellsize_resx cellsize_resy<<<$($libDir/getRasterInfoNative.py $outputHucDataDir/dem.tif)
 Tcount
 
-echo $ndv
-if [ ${ndv%%.*} -ge 0 ]; then
-      $ndv=-9999
-fi
-
 ## RASTERIZE NLD POLYLINES ##
 echo -e $startDiv"Rasterize all NLD polylines using zelev vertices"$stopDiv
 date -u

--- a/lib/run_by_unit.sh
+++ b/lib/run_by_unit.sh
@@ -245,7 +245,7 @@ Tcount
 
 if [[ ! -f $outputHucDataDir/demDerived_reaches_split.gpkg ]] ; then
   echo "No AHPs point(s) within HUC $hucNumber boundaries. Aborting run_by_unit.sh"
-  # rm -rf $outputHucDataDir
+  rm -rf $outputHucDataDir
   exit 0
 fi
 

--- a/lib/split_flows.py
+++ b/lib/split_flows.py
@@ -37,6 +37,11 @@ toMetersConversion = 1e-3
 
 print('Loading data ...')
 flows = gpd.read_file(flows_fileName)
+
+if not len(flows) > 0:
+    print ("No relevant streams within HUC boundaries.")
+    sys.exit(0)
+
 WBD8 = gpd.read_file(huc8_filename)
 #dem = Raster(dem_fileName)
 dem = rasterio.open(dem_fileName,'r')


### PR DESCRIPTION
Fixes non-zero exit statuses for Great Lakes, HI, and PR #159

## Changes

- adds a catch in split_flows.py to identify HUCs with no dem derived streams (Lake HUCs)
-  reprojected HI and PR rasters to `USA_Contiguous_Albers_Equal_Area_Conic_USGS_version`
- removed 04260000, 04280002, and 0426 from included HUC lists


## To do 

- Opened ticket #168 to provide a more long term solution to raster projection. This will not be included in FIM v3.0
