### PR TITLE
Hotfix for addressing ndv in rasterized levee lines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,15 @@
 All notable changes to this project will be documented in this file.
 We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 
+## v3.0.0.3 - 2021-01-14 - [PR #210](https://github.com/NOAA-OWP/cahaba/pull/210)
+
+Hotfix for handling nodata value in rasterized levee lines.
+
+### Changes
+
+ - Resolves bug for HUCs where `$ndv > 0` (Great Lakes region).
+ - Initialize the `nld_rasterized_elev.tif` using a value of `-9999` instead of `$ndv`.
+ 
 ## v3.0.0.2 - 2021-01-06 - [PR #200](https://github.com/NOAA-OWP/cahaba/pull/200)
 
 Patch to address AHPSs mapping errors.

--- a/lib/run_by_unit.sh
+++ b/lib/run_by_unit.sh
@@ -96,7 +96,7 @@ echo -e $startDiv"Rasterize all NLD multilines using zelev vertices"$stopDiv
 date -u
 Tstart
 [ ! -f $outputHucDataDir/nld_rasterized_elev.tif ] && [ -f $outputHucDataDir/nld_subset_levees.gpkg ] && \
-gdal_rasterize -l nld_subset_levees -3d -at -init $ndv -te $xmin $ymin $xmax $ymax -ts $ncols $nrows -ot Float32 -of GTiff -co "COMPRESS=LZW" -co "BIGTIFF=YES" -co "TILED=YES" $outputHucDataDir/nld_subset_levees.gpkg $outputHucDataDir/nld_rasterized_elev.tif
+gdal_rasterize -l nld_subset_levees -3d -at -init -9999 -a_nodata $ndv -te $xmin $ymin $xmax $ymax -ts $ncols $nrows -ot Float32 -of GTiff -co "COMPRESS=LZW" -co "BIGTIFF=YES" -co "TILED=YES" $outputHucDataDir/nld_subset_levees.gpkg $outputHucDataDir/nld_rasterized_elev.tif
 Tcount
 
 ## CONVERT TO METERS ##
@@ -138,7 +138,7 @@ echo -e $startDiv"Burn nld levees into dem & convert nld elev to meters (*Overwr
 date -u
 Tstart
 [ -f $outputHucDataDir/nld_rasterized_elev.tif ] && \
-gdal_calc.py --quiet --type=Float32 --overwrite --NoDataValue $ndv --co "BLOCKXSIZE=512" --co "BLOCKYSIZE=512" --co "TILED=YES" --co "COMPRESS=LZW" --co "BIGTIFF=YES" -A $outputHucDataDir/dem_meters.tif -B $outputHucDataDir/nld_rasterized_elev.tif --outfile="$outputHucDataDir/dem_meters.tif" --calc="maximum(A,(B*0.3048))" --NoDataValue=$ndv
+gdal_calc.py --quiet --type=Float32 --overwrite --NoDataValue $ndv --co "BLOCKXSIZE=512" --co "BLOCKYSIZE=512" --co "TILED=YES" --co "COMPRESS=LZW" --co "BIGTIFF=YES" -A $outputHucDataDir/dem_meters.tif -B $outputHucDataDir/nld_rasterized_elev.tif --outfile="$outputHucDataDir/dem_meters.tif" --calc="maximum(A,((B>-9999)*0.3048))" --NoDataValue=$ndv
 Tcount
 
 ## DEM Reconditioning ##


### PR DESCRIPTION
Previous configuration for the gdal_rasterize step did not assign a nodata value when converting levee lines to a raster. This was not an issue for any of the hucs that use a large negative value to denote nodata (inherited from elev_cm.tif). However, some hucs (Great Lakes region) are formatted as 16-bit unsigned integers and use a value of 65535 to assign nodata grid values. This led to issues in the “burn levees into dem” step when performing the gdal_calc maximum function → dem_meters.tif.
Solution:

- Initialize the nld_rasterized_elev.tif using a value of -9999. All grid values contain valid levee elevation values or -9999.
- Revised the “burn levees into dem” gdal_calc equation → `-calc="maximum(A,((B>-9999)*0.3048))"`
- This revised equation ignores all nld_rasterized_elev.tif  values < -9999 when performing the max function


## Testing
I tested the new feature branch on HUCS 04050003, 05120201, & 08090203 (MS & FR). Confirmed that the resulting dem_meters.tif and REM outputs were resolved.

## Screenshots
![levee_ndv_bug](https://user-images.githubusercontent.com/69868854/104485803-92b63b80-5590-11eb-856d-d25e25f7d304.png)
![levee_ndv_solution](https://user-images.githubusercontent.com/69868854/104485811-95189580-5590-11eb-8064-21df215d93a1.png)

