### PR TITLE
[1pt] PR: hotfix to aggregate script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,19 @@
 All notable changes to this project will be documented in this file.
 We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 
+## v3.0.4.2 - 2021-02-12 - [PR #255](https://github.com/NOAA-OWP/cahaba/pull/255)
+
+Addresses issue when running on HUC6 scale.
+
+### Changes
+
+ - `src.json` should be fixed and slightly smaller by removing whitespace.
+ - Rasters are about the same size as running fim as huc6 (compressed and tiled; aggregated are slightly larger).
+ - Naming convention and feature id attribute are only added to the aggregated hucs.
+ - HydroIDs are different for huc6 vs aggregated huc8s mostly due to forced split at huc boundaries (so long we use consistent workflow it shouldn't matter).
+ - Fixed known issue where sometimes an incoming stream is not included in the final selection will affect aggregate outputs.
+ 
+<br/><br/>
 ## v3.0.4.0 - 2021-02-10 - [PR #256](https://github.com/NOAA-OWP/cahaba/pull/256)
 
 New python script "wrappers" for using `inundation.py`.

--- a/lib/aggregate_fim_outputs.py
+++ b/lib/aggregate_fim_outputs.py
@@ -65,6 +65,7 @@ def aggregate_fim_outputs(fim_out_dir):
     for huc6 in huc6_list:
 
         huc6_dir = os.path.join(fim_out_dir,'aggregate_fim_outputs',huc6)
+
         # aggregate file paths
         rem_mosaic = os.path.join(huc6_dir,'rem_zeroed_masked.tif')
         catchment_mosaic = os.path.join(huc6_dir,'gw_catchments_reaches_filtered_addedAttributes.tif')
@@ -82,33 +83,34 @@ def aggregate_fim_outputs(fim_out_dir):
 
                 rem_src = rasterio.open(rem)
                 rem_files_to_mosaic.append(rem_src)
-                mosaic, out_trans = merge(rem_files_to_mosaic)
-                out_meta = rem_src.meta.copy()
 
-                out_meta.update({"driver": "GTiff", "height": mosaic.shape[1], "width": mosaic.shape[2], "dtype": str(mosaic.dtype), "transform": out_trans,"crs": PREP_PROJECTION})
+            mosaic, out_trans = merge(rem_files_to_mosaic)
+            out_meta = rem_src.meta.copy()
+            out_meta.update({"driver": "GTiff", "height": mosaic.shape[1], "width": mosaic.shape[2], "dtype": str(mosaic.dtype), "transform": out_trans,"crs": PREP_PROJECTION,'compress': 'lzw'})
 
-                with rasterio.open(rem_mosaic, "w", **out_meta) as dest:
-                    dest.write(mosaic)
+            with rasterio.open(rem_mosaic, "w", **out_meta) as dest:
+                dest.write(mosaic)
 
-                del rem_files_to_mosaic,rem_src,out_meta,mosaic
+            del rem_files_to_mosaic,rem_src,out_meta,mosaic
 
-                # aggregate and mosaic catchments
-                catchment_list = [os.path.join(fim_out_dir,huc,'gw_catchments_reaches_filtered_addedAttributes.tif') for huc in subset_huc6_list]
+            # aggregate and mosaic catchments
+            catchment_list = [os.path.join(fim_out_dir,huc,'gw_catchments_reaches_filtered_addedAttributes.tif') for huc in subset_huc6_list]
 
-                cat_files_to_mosaic = []
+            cat_files_to_mosaic = []
 
-                for cat in catchment_list:
-                    cat_src = rasterio.open(cat)
-                    cat_files_to_mosaic.append(cat_src)
+            for cat in catchment_list:
+                cat_src = rasterio.open(cat)
+                cat_files_to_mosaic.append(cat_src)
 
-                mosaic, out_trans = merge(cat_files_to_mosaic)
-                out_meta = cat_src.meta.copy()
-                out_meta.update({"driver": "GTiff", "height": mosaic.shape[1], "width": mosaic.shape[2], "dtype": str(mosaic.dtype), "transform": out_trans,"crs": PREP_PROJECTION})
+            mosaic, out_trans = merge(cat_files_to_mosaic)
+            out_meta = cat_src.meta.copy()
 
-                with rasterio.open(catchment_mosaic, "w", **out_meta) as dest:
-                    dest.write(mosaic)
+            out_meta.update({"driver": "GTiff", "height": mosaic.shape[1], "width": mosaic.shape[2], "dtype": str(mosaic.dtype), "transform": out_trans,"crs": PREP_PROJECTION,'compress': 'lzw'})
 
-                del cat_files_to_mosaic,cat_src,out_meta,mosaic
+            with rasterio.open(catchment_mosaic, "w", **out_meta) as dest:
+                dest.write(mosaic)
+
+            del cat_files_to_mosaic,cat_src,out_meta,mosaic
 
         else:
             # original file paths

--- a/lib/aggregate_fim_outputs.py
+++ b/lib/aggregate_fim_outputs.py
@@ -113,7 +113,7 @@ def aggregate_fim_outputs(fim_out_dir):
         else:
             # original file paths
             rem_filename = os.path.join(fim_out_dir,huc6,'rem_zeroed_masked.tif')
-            catchment_filename = os.path.join(fim_out_dir,huc6,'rem_zeroed_masked.tif')
+            catchment_filename = os.path.join(fim_out_dir,huc6,'gw_catchments_reaches_filtered_addedAttributes.tif')
 
             shutil.copy(rem_filename, rem_mosaic)
             shutil.copy(catchment_filename, catchment_mosaic)

--- a/lib/aggregate_fim_outputs.py
+++ b/lib/aggregate_fim_outputs.py
@@ -70,10 +70,10 @@ def aggregate_fim_outputs(fim_out_dir):
 
     for huc6 in huc6_list:
 
+        ## add feature_id to aggregate src
         aggregate_hydrotable = os.path.join(fim_out_dir,'aggregate_fim_outputs',str(huc6),'hydroTable.csv')
         aggregate_src = os.path.join(fim_out_dir,'aggregate_fim_outputs',str(huc[0:6]),f'rating_curves_{huc[0:6]}.json')
 
-        # add feature_id to aggregate src
         # Open aggregate src for writing feature_ids to
         src_data = {}
         with open(aggregate_src) as jsonf:
@@ -87,11 +87,10 @@ def aggregate_fim_outputs(fim_out_dir):
                     src_data[row['HydroID'].lstrip('0')]['nwm_feature_id'] = row['feature_id']
 
         # Write src_data to JSON file
-        with open(aggregate_hydrotable, 'w') as jsonf:
+        with open(aggregate_src, 'w') as jsonf:
             json.dump(src_data, jsonf)
 
-    for huc6 in huc6_list:
-
+        ## aggregate rasters
         huc6_dir = os.path.join(fim_out_dir,'aggregate_fim_outputs',huc6)
 
         # aggregate file paths
@@ -119,7 +118,7 @@ def aggregate_fim_outputs(fim_out_dir):
                 out_meta = rem_src.meta.copy()
                 out_meta.update({"driver": "GTiff", "height": mosaic.shape[1], "width": mosaic.shape[2], "dtype": str(mosaic.dtype), "transform": out_trans,"crs": PREP_PROJECTION,'compress': 'lzw'})
 
-                with rasterio.open(rem_mosaic, "w", **out_meta) as dest:
+                with rasterio.open(rem_mosaic, "w", **out_meta, tiled=True, blockxsize=256, blockysize=256, BIGTIFF='YES') as dest:
                     dest.write(mosaic)
 
                 del rem_files_to_mosaic,rem_src,out_meta,mosaic
@@ -142,9 +141,9 @@ def aggregate_fim_outputs(fim_out_dir):
                 mosaic, out_trans = merge(cat_files_to_mosaic)
                 out_meta = cat_src.meta.copy()
 
-                out_meta.update({"driver": "GTiff", "height": mosaic.shape[1], "width": mosaic.shape[2], "dtype": str(mosaic.dtype), "transform": out_trans,"crs": PREP_PROJECTION,'compress': 'lzw'})
+                out_meta.update({"driver": "GTiff", "height": mosaic.shape[1], "width": mosaic.shape[2], "dtype": str(mosaic.dtype), "transform": out_trans,"crs": PREP_PROJECTION,'compress': 'lzw'}) #"compress": "JPEG",  "photometric": "YCBCR"
 
-                with rasterio.open(catchment_mosaic, "w", **out_meta) as dest:
+                with rasterio.open(catchment_mosaic, "w", **out_meta, tiled=True, blockxsize=256, blockysize=256, BIGTIFF='YES') as dest:
                     dest.write(mosaic)
 
                 del cat_files_to_mosaic,cat_src,out_meta,mosaic

--- a/lib/aggregate_fim_outputs.py
+++ b/lib/aggregate_fim_outputs.py
@@ -95,7 +95,7 @@ def aggregate_fim_outputs(fim_out_dir):
         huc6_dir = os.path.join(fim_out_dir,'aggregate_fim_outputs',huc6)
 
         # aggregate file paths
-        rem_mosaic = os.path.join(huc6_dir,f'hand_grid_{huc6}.tif'))
+        rem_mosaic = os.path.join(huc6_dir,f'hand_grid_{huc6}.tif')
         catchment_mosaic = os.path.join(huc6_dir,f'catchments_{huc6}.tif')
 
         if huc6 not in huc_list:

--- a/lib/aggregate_fim_outputs.py
+++ b/lib/aggregate_fim_outputs.py
@@ -72,7 +72,7 @@ def aggregate_fim_outputs(fim_out_dir):
 
         ## add feature_id to aggregate src
         aggregate_hydrotable = os.path.join(fim_out_dir,'aggregate_fim_outputs',str(huc6),'hydroTable.csv')
-        aggregate_src = os.path.join(fim_out_dir,'aggregate_fim_outputs',str(huc[0:6]),f'rating_curves_{huc[0:6]}.json')
+        aggregate_src = os.path.join(fim_out_dir,'aggregate_fim_outputs',str(huc6),f'rating_curves_{huc6}.json')
 
         # Open aggregate src for writing feature_ids to
         src_data = {}
@@ -141,7 +141,7 @@ def aggregate_fim_outputs(fim_out_dir):
                 mosaic, out_trans = merge(cat_files_to_mosaic)
                 out_meta = cat_src.meta.copy()
 
-                out_meta.update({"driver": "GTiff", "height": mosaic.shape[1], "width": mosaic.shape[2], "dtype": str(mosaic.dtype), "transform": out_trans,"crs": PREP_PROJECTION,'compress': 'lzw'}) #"compress": "JPEG",  "photometric": "YCBCR"
+                out_meta.update({"driver": "GTiff", "height": mosaic.shape[1], "width": mosaic.shape[2], "dtype": str(mosaic.dtype), "transform": out_trans,"crs": PREP_PROJECTION,'compress': 'lzw'})
 
                 with rasterio.open(catchment_mosaic, "w", **out_meta, tiled=True, blockxsize=256, blockysize=256, BIGTIFF='YES') as dest:
                     dest.write(mosaic)

--- a/lib/aggregate_fim_outputs.py
+++ b/lib/aggregate_fim_outputs.py
@@ -53,7 +53,7 @@ def aggregate_fim_outputs(fim_out_dir):
                 with open(aggregate_src, "r+") as file:
                     data = json.load(file)
                     data.update(src)
-                    
+
                 with open(aggregate_src, 'w') as outfile:
                     json.dump(data, outfile)
             else:
@@ -68,12 +68,10 @@ def aggregate_fim_outputs(fim_out_dir):
 
 
     for huc6 in huc6_list:
-
         huc6_dir = os.path.join(fim_out_dir,'aggregate_fim_outputs',huc6)
-
         # aggregate file paths
-        rem_mosaic = os.path.join(huc6_dir,'rem_zeroed_masked.tif')
-        catchment_mosaic = os.path.join(huc6_dir,'gw_catchments_reaches_filtered_addedAttributes.tif')
+        rem_mosaic = os.path.join(huc6_dir,f'hand_grid_{huc6}.tif'))
+        catchment_mosaic = os.path.join(huc6_dir,f'catchments_{huc6}.tif')
 
         if huc6 not in huc_list:
 

--- a/lib/output_cleanup.py
+++ b/lib/output_cleanup.py
@@ -50,26 +50,6 @@ def output_cleanup(huc_number, output_folder_path, additional_whitelist, is_prod
         # Step 1, keep only files that Viz needs
         whitelist_directory(output_folder_path, viz_whitelist, additional_whitelist)
 
-        # Step 2, add feature_id to src.json and rename file
-        # Open src.json for writing feature_ids to
-        src_data = {}
-        with open(os.path.join(output_folder_path, 'src.json')) as jsonf:
-            src_data = json.load(jsonf)
-
-        with open(os.path.join(output_folder_path, 'hydroTable.csv')) as csvf:
-            csvReader = csv.DictReader(csvf)
-            for row in csvReader:
-                if row['HydroID'].lstrip('0') in src_data and 'nwm_feature_id' not in src_data[row['HydroID'].lstrip('0')]:
-                    src_data[row['HydroID'].lstrip('0')]['nwm_feature_id'] = row['feature_id']
-
-        # Write src_data to JSON file
-        with open(os.path.join(output_folder_path, f'rating_curves_{huc_number}.json'), 'w') as jsonf:
-            json.dump(src_data, jsonf)
-
-        # Step 3, copy files to desired names
-        shutil.copy(os.path.join(output_folder_path, 'rem_zeroed_masked.tif'), os.path.join(output_folder_path, f'hand_grid_{huc_number}.tif'))
-        shutil.copy(os.path.join(output_folder_path, 'gw_catchments_reaches_filtered_addedAttributes.tif'), os.path.join(output_folder_path, f'catchments_{huc_number}.tif'))
-
 def whitelist_directory(directory_path, whitelist, additional_whitelist):
     # Add any additional files to the whitelist that the user wanted to keep
     if additional_whitelist:


### PR DESCRIPTION
Addresses issue when running on HUC6 scale.

- src should be fixed and slightly smaller by removing whitespace

- rasters are about the same size as running fim as huc6 (compressed and tiled; aggregated are slightly larger)

- naming convention and feature id attribute are only added to the aggregated hucs (this bullet and the next one assume that Viz will not use the huc8 layer outputs)

- HydroIDs are different for huc6 vs aggregated huc8s mostly due to forced split at huc boundaries (so long we use consistent workflow it shouldn't matter)

- known issue where sometimes an incoming stream is not included in the final selection (#238) will affect aggregate outputs