### PR TITLE
Adding HAND SRC datum elev values to hydroTable.csv output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,15 @@
 All notable changes to this project will be documented in this file.
 We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 
+## v3.0.5.2 - 2021-02-23
+
+Adding HAND SRC datum elev values to `hydroTable.csv` output
+
+### Changes
+
+ - Updated `add_crosswalk.py` to included "Median_Thal_Elev_m" variable outputs in hydroTable.csv
+ - Renamed hydroid attribute in `rem.py` to "Median" in case we want to include other statistics in the future (e.g. min, max, range etc.)
+
 ## v3.0.5.1 - 2021-02-22
 
 Fixed `TEST_CASES_DIR` path in `tests/utils/shared_variables.py`.

--- a/lib/add_crosswalk.py
+++ b/lib/add_crosswalk.py
@@ -220,9 +220,9 @@ def add_crosswalk(input_catchments_fileName,input_flows_fileName,input_srcbase_f
     output_hydro_table = output_hydro_table.merge(input_huc.loc[:,[FIM_ID,'HUC8']],how='left',on=FIM_ID)
 
     if output_flows.HydroID.dtype != 'str': output_flows.HydroID = output_flows.HydroID.astype(str)
-    output_hydro_table = output_hydro_table.merge(output_flows.loc[:,['HydroID','LakeID']],how='left',on='HydroID')
+    output_hydro_table = output_hydro_table.merge(output_flows.loc[:,['HydroID','LakeID','Median_Thal_Elev_m']],how='left',on='HydroID')
     output_hydro_table['LakeID'] = output_hydro_table['LakeID'].astype(int)
-
+    output_hydro_table['Median_Thal_Elev_m'] = output_hydro_table['Median_Thal_Elev_m'].astype(float).round(2)
     output_hydro_table = output_hydro_table.rename(columns={'HUC8':'HUC'})
     if output_hydro_table.HUC.dtype != 'str': output_hydro_table.HUC = output_hydro_table.HUC.astype(str)
 

--- a/lib/rem.py
+++ b/lib/rem.py
@@ -111,7 +111,7 @@ def rel_dem(dem_fileName, pixel_watersheds_fileName, rem_fileName, thalweg_raste
 ###############################################
     # Merge and export dictionary to to_csv
     catchment_min_dict_df = pd.DataFrame.from_dict(catchment_min_dict, orient='index') # convert dict to dataframe
-    catchment_min_dict_df.columns = ['Min_Thal_Elev_meters']
+    catchment_min_dict_df.columns = ['Median_Thal_Elev_m']
     catchment_hydroid_dict_df = pd.DataFrame.from_dict(catchment_hydroid_dict, orient='index') # convert dict to dataframe
     catchment_hydroid_dict_df.columns = ['HydroID']
     merge_df = catchment_hydroid_dict_df.merge(catchment_min_dict_df, left_index=True, right_index=True)
@@ -119,7 +119,7 @@ def rel_dem(dem_fileName, pixel_watersheds_fileName, rem_fileName, thalweg_raste
     merge_df.to_csv(hand_ref_elev_fileName,index=True) # export dataframe to csv file
 
     # Merge the HAND reference elvation by HydroID dataframe with the demDerived_reaches layer (add new layer attribute)
-    merge_df = merge_df.groupby(['HydroID']).median() # median value of all Min_Thal_Elev_meters for pixel catchments in each HydroID reach
+    merge_df = merge_df.groupby(['HydroID']).median() # median value of all Median_Thal_Elev_m for pixel catchments in each HydroID reach
     input_reaches = gpd.read_file(dem_reaches_filename)
     input_reaches = input_reaches.merge(merge_df, on='HydroID') # merge dataframes by HydroID variable
     input_reaches.to_file(dem_reaches_filename,driver=getDriver(dem_reaches_filename),index=False)


### PR DESCRIPTION
The current dev is exporting the HAND thalweg reference elevation values for each pixel catchment (hand_ref_elev_table.csv) as well as the median thalweg elevation value for each hydroid segment (demDerived_reaches_split_filtered_addedAttributes_crosswalked.gpkg). These outputs provide the elevation datum for each of the synthetic rating curves. This feature branch exports the median thalweg elevation values as a new attribute in the hydroTable.csv to help facilitate future rating curve comparisons. This address #268.

## Changes

- add_crosswalk.py: included "Median_Thal_Elev_m" variable outputs to hydroTable.csv
- rem.py: Renamed hydroid attribute to "Median" in case we want to include other statistics in the future (e.g. min, max, range etc.)

## Screenshots
![image](https://user-images.githubusercontent.com/69868854/108874281-a1e1cd80-75c1-11eb-9951-863d31690a2f.png)

