### PR TITLE
[1pt] Update spatial option when performing eval plots (Dev plots spatial)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
  ### Changes
  - Remove required file dependencies from spatial option. Does require the WBD layer which should be specified in .env file. 
  - Produces outputs in a format consistent with requirements needed for publishing.
+ - Preserves leading zeros in huc information for all outputs from eval_plots.py
 ### Additions
  - Creates 2 shapefiles:
  - fim_performance_points.shp -- This layer consists of all evaluated ahps points (with metrics). Spatial data retrieved from WRDS on the fly.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 
 ### Additions
 - Creates `fim_performance_points.shp`: this layer consists of all evaluated ahps points (with metrics). Spatial data retrieved from WRDS on the fly.
-- Creates `fim_performance_polys.shp` -- This layer consists of all evaluated huc8s (with metrics). Spatial data retrieved from WBD layer.
+- Creates `fim_performance_polys.shp`: this layer consists of all evaluated huc8s (with metrics). Spatial data retrieved from WBD layer.
 <br/><br/>
 
 ## v3.0.12.0 - 2021-03-26 - [PR #327](https://github.com/NOAA-OWP/cahaba/pull/237)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
  - Removes file dependencies from spatial option. Does require the WBD layer which should be specified in `.env` file. 
  - Produces outputs in a format consistent with requirements needed for publishing.
  - Preserves leading zeros in huc information for all outputs from `eval_plots.py`.
- - 
+
 ### Additions
 - Creates `fim_performance_points.shp`: this layer consists of all evaluated ahps points (with metrics). Spatial data retrieved from WRDS on the fly.
 - Creates `fim_performance_polys.shp` -- This layer consists of all evaluated huc8s (with metrics). Spatial data retrieved from WBD layer.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,18 +2,20 @@ All notable changes to this project will be documented in this file.
 We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 
 
-## v3.0.14.0 - 2021-03-26 - [PR #336](https://github.com/NOAA-OWP/cahaba/pull/336)
+## v3.0.12.1 - 2021-03-26 - [PR #336](https://github.com/NOAA-OWP/cahaba/pull/336)
 
- Fix spatial option when creating plots
+ Fix spatial option in `eval_plots.py` when creating plots and spatial outputs.
+ 
  ### Changes
- - Remove required file dependencies from spatial option. Does require the WBD layer which should be specified in .env file. 
+ - Removes file dependencies from spatial option. Does require the WBD layer which should be specified in `.env` file. 
  - Produces outputs in a format consistent with requirements needed for publishing.
- - Preserves leading zeros in huc information for all outputs from eval_plots.py
+ - Preserves leading zeros in huc information for all outputs from `eval_plots.py`.
+ - 
 ### Additions
- - Creates 2 shapefiles:
- - fim_performance_points.shp -- This layer consists of all evaluated ahps points (with metrics). Spatial data retrieved from WRDS on the fly.
- - fim_performance_polys.shp -- This layer consists of all evaluated huc8s (with metrics). Spatial data retrieved from WBD layer.
+- Creates `fim_performance_points.shp`: this layer consists of all evaluated ahps points (with metrics). Spatial data retrieved from WRDS on the fly.
+- Creates `fim_performance_polys.shp` -- This layer consists of all evaluated huc8s (with metrics). Spatial data retrieved from WBD layer.
 <br/><br/>
+
 ## v3.0.12.0 - 2021-03-26 - [PR #327](https://github.com/NOAA-OWP/cahaba/pull/237)
 
  Add more detail/information to plotting capabilities.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,18 @@
 All notable changes to this project will be documented in this file.
 We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 
+
+## v3.0.14.0 - 2021-03-26 - [PR #336](https://github.com/NOAA-OWP/cahaba/pull/336)
+
+ Fix spatial option when creating plots
+ ### Changes
+ - Remove required file dependencies from spatial option. Does require the WBD layer which should be specified in .env file. 
+ - Produces outputs in a format consistent with requirements needed for publishing.
+### Additions
+ - Creates 2 shapefiles:
+ - fim_performance_points.shp -- This layer consists of all evaluated ahps points (with metrics). Spatial data retrieved from WRDS on the fly.
+ - fim_performance_polys.shp -- This layer consists of all evaluated huc8s (with metrics). Spatial data retrieved from WBD layer.
+<br/><br/>
 ## v3.0.12.0 - 2021-03-26 - [PR #327](https://github.com/NOAA-OWP/cahaba/pull/237)
 
  Add more detail/information to plotting capabilities.

--- a/tools/eval_plots.py
+++ b/tools/eval_plots.py
@@ -643,7 +643,7 @@ def eval_plots(metrics_csv, workspace, versions = [], stats = ['CSI','FAR','TPR'
         #Merge flows and maps into single DataFrame
         flows_maps = pd.merge(flows,maps, how = 'left', left_on = ['nws_lid','source','category'], right_on = ['nws_lid','source','category'])        
         # combine flows_maps to spatial layer (gdf)
-        gdf_merged = gdf.merge(flows_maps, on = 'nws_lid')
+        joined = joined.merge(flows_maps, on = 'nws_lid')
         '''
         ################################################################
         #This section joins ble (FR) metrics to a spatial layer of HUCs.
@@ -672,32 +672,12 @@ if __name__ == '__main__':
     parser.add_argument('-v', '--versions', help = 'List of versions to be plotted/aggregated. Versions are filtered using the "startswith" approach. For example, ["fim_","fb1"] would retain all versions that began with "fim_" (e.g. fim_1..., fim_2..., fim_3...) as well as any feature branch that began with "fb". An other example ["fim_3","fb"] would result in all fim_3 versions being plotted along with the fb.', nargs = '+', default = [])
     parser.add_argument('-s', '--stats', help = 'List of statistics (abbrev to 3 letters) to be plotted/aggregated', nargs = '+', default = ['CSI','TPR','FAR'], required = False)
     parser.add_argument('-q', '--alternate_ahps_query',help = 'Alternate filter query for AHPS. Default is: "not nws_lid.isnull() & not flow.isnull() & masked_perc<97 & not nws_lid in @bad_sites" where bad_sites are (grfi2,ksdm7,hohn4,rwdn4)', default = False, required = False)
-    parser.add_argument('-sp', '--spatial', help = 'If spatial layers are desired, supply a csv with 3 lines of the following format: metadata, path/to/metadata/shapefile\nevaluated, path/to/evaluated/shapefile\nstatic, path/to/static/shapefile.', default = False, required = False)
+    parser.add_argument('-sp', '--spatial', help = 'If enabled, creates spatial layers with metrics populated in attribute table.', default = False, required = False)
     parser.add_argument('-f', '--fim_1_ms', help = 'If enabled fim_1 rows will be duplicated and extent config assigned "ms" so that fim_1 can be shown on mainstems plots/stats', action = 'store_true', required = False)
     parser.add_argument('-i', '--site_plots', help = 'If enabled individual barplots for each site are created.', action = 'store_true', required = False)
     
     # Extract to dictionary and assign to variables
     args = vars(parser.parse_args())
-
-    # If errors occur reassign error to True
-    error = False
-    # Create dictionary if file specified for spatial_ahps
-    if args['spatial']:
-        # Create dictionary
-        spatial_dict = {}
-        with open(args['spatial']) as file:
-            for line in file:
-                key, value = line.strip('\n').split(',')
-                spatial_dict[key] = Path(value)
-        args['spatial'] = spatial_dict
-        # Check that all required keys are present and overwrite args with spatial_dict
-        required_keys = set(['metadata', 'evaluated', 'static'])
-        if required_keys - spatial_dict.keys():
-          print('\n Required keys are: metadata, evaluated, static')
-          error = True
-        else:
-            args['spatial'] = spatial_dict
-
 
     # Finalize Variables
     m = args['metrics_csv']
@@ -710,5 +690,4 @@ if __name__ == '__main__':
     i = args['site_plots']
 
     # Run eval_plots function
-    if not error:
-        eval_plots(metrics_csv = m, workspace = w, versions = v, stats = s, alternate_ahps_query = q, spatial = sp, fim_1_ms = f, site_barplots = i)
+    eval_plots(metrics_csv = m, workspace = w, versions = v, stats = s, alternate_ahps_query = q, spatial = sp, fim_1_ms = f, site_barplots = i)

--- a/tools/eval_plots.py
+++ b/tools/eval_plots.py
@@ -8,6 +8,7 @@ import numpy as np
 import matplotlib.pyplot as plt
 import seaborn as sns
 import re
+import os
 import sys
 sys.path.append('/foss_fim/src')
 from utils.shared_variables import VIZ_PROJECTION

--- a/tools/eval_plots.py
+++ b/tools/eval_plots.py
@@ -381,6 +381,12 @@ def eval_plots(metrics_csv, workspace, versions = [], stats = ['CSI','FAR','TPR'
             site subdirectories are the following files:
                 csi_<site_name>_<benchmark_source>_<configuration>.png: A barplot
                     of CSI for each version for all magnitudes for the site.
+        Optional (if spatial argument supplied): 
+            fim_performance_points.shp -- A shapefile of ahps points with 
+            metrics contained in attribute table.
+            fim_performance_polys.shp -- A shapefile of huc8 polygons with
+            metrics contained in attribute table.
+            
 
 
     Parameters
@@ -409,16 +415,15 @@ def eval_plots(metrics_csv, workspace, versions = [], stats = ['CSI','FAR','TPR'
         The default is false. Currently the default ahps query is same
         as done for apg goals. If a different query is desired it can be
         supplied and it will supercede the default query.
-    spatial_ahps : DICTIONARY, optional
-        The default is false. A dictionary with keys as follows:
-            'static': Path to AHPS point file created during creation of
-                FIM 3 static libraries.
-            'evaluated': Path to extent file created during the creation
-                of the NWS/USGS AHPS preprocessing.
-            'metadata': Path to previously created file that contains
-                metadata about each site (feature_id, wfo, rfc and etc).
-        No spatial layers will be created if set to False, if a dictionary
-        is supplied then a spatial layer is produced.
+    spatial : BOOL, optional
+        Creates spatial datasets of the base unit (ble: huc polygon, ahps: point) 
+        with metrics contained in attribute tables. The geospatial data is 
+        either supplied in the .env file (WBD Huc layer) or from WRDS (ahps).
+        The outputs are consistent with requirements set forth by the vizualization team.
+        Additionally, there is a commented out section where if the user
+        passes the extent files generated during creation of nws/usgs ahps
+        preprocessing, the actual maps and flows used for evaluation are
+        appended to the ahps shapefile output. 
     fim_1_ms: BOOL
         Default is false. If True then fim_1 rows are duplicated with
         extent_config set to MS. This allows for FIM 1 to be included

--- a/tools/eval_plots.py
+++ b/tools/eval_plots.py
@@ -677,7 +677,7 @@ if __name__ == '__main__':
     parser.add_argument('-v', '--versions', help = 'List of versions to be plotted/aggregated. Versions are filtered using the "startswith" approach. For example, ["fim_","fb1"] would retain all versions that began with "fim_" (e.g. fim_1..., fim_2..., fim_3...) as well as any feature branch that began with "fb". An other example ["fim_3","fb"] would result in all fim_3 versions being plotted along with the fb.', nargs = '+', default = [])
     parser.add_argument('-s', '--stats', help = 'List of statistics (abbrev to 3 letters) to be plotted/aggregated', nargs = '+', default = ['CSI','TPR','FAR'], required = False)
     parser.add_argument('-q', '--alternate_ahps_query',help = 'Alternate filter query for AHPS. Default is: "not nws_lid.isnull() & not flow.isnull() & masked_perc<97 & not nws_lid in @bad_sites" where bad_sites are (grfi2,ksdm7,hohn4,rwdn4)', default = False, required = False)
-    parser.add_argument('-sp', '--spatial', help = 'If enabled, creates spatial layers with metrics populated in attribute table.', default = False, required = False)
+    parser.add_argument('-sp', '--spatial', help = 'If enabled, creates spatial layers with metrics populated in attribute table.', action = 'store_true', required = False)
     parser.add_argument('-f', '--fim_1_ms', help = 'If enabled fim_1 rows will be duplicated and extent config assigned "ms" so that fim_1 can be shown on mainstems plots/stats', action = 'store_true', required = False)
     parser.add_argument('-i', '--site_plots', help = 'If enabled individual barplots for each site are created.', action = 'store_true', required = False)
     


### PR DESCRIPTION
Spatial option of eval_plots.py was not correctly updated to reflect new data requirements. Simplified user experience in running spatial option by removing required file inputs. Address #335


## Changes
Spatial option argument in eval_plots.py doesn't require user input file. Instead it generates required spatial data on the fly or uses existing file paths specified in the .env file. Outputs two spatial files with metrics populated in attribute table. A point layer for ahps sites and a polygon layer for ble.

Modification to how eval_plots.py reads the metrics csv as it now preserves leading zeros in HUCs.

## Testing
An example run is:
```python3 eval_plots.py -m /path/to/metrics/csv -w /path/to/output/workspace -v fim_3_0_9_0_ -sp```

