### PR TITLE
PR: Remove Great Lakes from wbd buffer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 
 Remove Great Lakes coastlines from WBD buffer.
 
-## Additions
+## Changes
 - gl_water_polygons.gpkg layer is used to mask out Great Lakes boundaries and remove NHDPlus HR coastline segments.
 
 <br/><br/>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 All notable changes to this project will be documented in this file.
 We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 <br/><br/>
+## v3.0.15.10 - 2021-05-04 - [PR #375](https://github.com/NOAA-OWP/cahaba/pull/375)
+
+Remove Great Lakes coastlines from WBD buffer.
+
+## Additions
+- gl_water_polygons.gpkg layer is used to mask out Great Lakes boundaries and remove NHDPlus HR coastline segments.
+
+<br/><br/>
 ## v3.0.15.9 - 2021-05-03 - [PR #372](https://github.com/NOAA-OWP/cahaba/pull/372)
 
 Generate `nws_lid.gpkg`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 Remove Great Lakes coastlines from WBD buffer.
 
 ## Changes
-- gl_water_polygons.gpkg layer is used to mask out Great Lakes boundaries and remove NHDPlus HR coastline segments.
+- `gl_water_polygons.gpkg` layer is used to mask out Great Lakes boundaries and remove NHDPlus HR coastline segments.
 
 <br/><br/>
 ## v3.0.15.9 - 2021-05-03 - [PR #372](https://github.com/NOAA-OWP/cahaba/pull/372)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 All notable changes to this project will be documented in this file.
 We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 <br/><br/>
-## v3.0.15.10 - 2021-05-05 - [PR #375](https://github.com/NOAA-OWP/cahaba/pull/375)
+## v3.0.15.10 - 2021-05-06 - [PR #375](https://github.com/NOAA-OWP/cahaba/pull/375)
 
 Remove Great Lakes coastlines from WBD buffer.
 

--- a/fim_run.sh
+++ b/fim_run.sh
@@ -116,7 +116,7 @@ export input_nwm_catchments=$inputDataDir/nwm_hydrofabric/nwm_catchments.gpkg
 export input_nwm_flows=$inputDataDir/nwm_hydrofabric/nwm_flows.gpkg
 export input_nhd_flowlines=$inputDataDir/nhdplus_vectors_aggregate/agg_nhd_streams_adj.gpkg
 export input_nhd_headwaters=$inputDataDir/nhdplus_vectors_aggregate/agg_nhd_headwaters_adj.gpkg
-
+export input_GL_boundaries=$inputDataDir/landsea/gl_water_polygons.gpkg
 ## Input handling ##
 $srcDir/check_huc_inputs.py -u "$hucList"
 

--- a/src/clip_vectors_to_wbd.py
+++ b/src/clip_vectors_to_wbd.py
@@ -22,14 +22,11 @@ def subset_vector_layers(hucCode,nwm_streams_filename,nhd_streams_filename,nwm_l
         print("Masking Great Lakes for HUC{} {}".format(hucUnitLength,hucCode),flush=True)
 
         # Buffer Great Lakes boundary
-        lakes_buffer = gl_lakes.copy()
-        lakes_buffer['geometry'] = gl_lakes.buffer(lake_buffer_distance)
+        gl_lakes = gl_lakes.geometry.buffer(lake_buffer_distance)
 
         # Removed buffered GL from WBD buffer
-        wbd_buffer = gpd.overlay(wbd_buffer, lakes_buffer, how='difference')
+        wbd_buffer = gpd.overlay(wbd_buffer, gl_lakes, how='difference')
         wbd_buffer.to_file(wbd_buffer_filename,driver=getDriver(wbd_buffer_filename),index=False)
-
-        del lakes_buffer
 
     else:
         wbd_buffer.to_file(wbd_buffer_filename,driver=getDriver(wbd_buffer_filename),index=False)

--- a/src/clip_vectors_to_wbd.py
+++ b/src/clip_vectors_to_wbd.py
@@ -48,6 +48,7 @@ def subset_vector_layers(hucCode,nwm_streams_filename,nhd_streams_filename,nwm_l
     # Find intersecting lakes and writeout
     print("Subsetting NWM Lakes for HUC{} {}".format(hucUnitLength,hucCode),flush=True)
     nwm_lakes = gpd.read_file(nwm_lakes_filename, mask = wbd_buffer)
+    nwm_lakes = nwm_lakes.loc[nwm_lakes.Shape_Area < 18990454000.0]
 
     if not nwm_lakes.empty:
         # Perform fill process to remove holes/islands in the NWM lake polygons

--- a/src/clip_vectors_to_wbd.py
+++ b/src/clip_vectors_to_wbd.py
@@ -13,8 +13,7 @@ def subset_vector_layers(hucCode,nwm_streams_filename,nhd_streams_filename,nwm_l
 
     # Get wbd buffer
     wbd = gpd.read_file(wbd_filename)
-    wbd_buffer = wbd.copy()
-    wbd_buffer['geometry'] = wbd.buffer(wbd_buffer_distance)
+    wbd_buffer = wbd.geometry.buffer(wbd_buffer_distance,resolution=32)
     projection = wbd_buffer.crs
 
     gl_lakes = gpd.read_file(great_lakes_filename, mask = wbd_buffer)

--- a/src/clip_vectors_to_wbd.py
+++ b/src/clip_vectors_to_wbd.py
@@ -17,13 +17,16 @@ def subset_vector_layers(hucCode,nwm_streams_filename,nhd_streams_filename,nwm_l
     wbd_buffer.geometry = wbd.geometry.buffer(wbd_buffer_distance,resolution=32)
     projection = wbd_buffer.crs
 
-    great_lakes = gpd.read_file(great_lakes_filename, mask = wbd_buffer)
+    great_lakes = gpd.read_file(great_lakes_filename, mask = wbd_buffer).reset_index(drop=True)
 
     if not great_lakes.empty:
         print("Masking Great Lakes for HUC{} {}".format(hucUnitLength,hucCode),flush=True)
 
-        # Buffer Great Lakes boundary
-        great_lakes['geometry'] = great_lakes.buffer(lake_buffer_distance)
+        # Clip excess lake area
+        great_lakes = gpd.clip(great_lakes, wbd_buffer)
+
+        # Buffer remaining lake area
+        great_lakes.geometry = great_lakes.buffer(lake_buffer_distance)
 
         # Removed buffered GL from WBD buffer
         wbd_buffer = gpd.overlay(wbd_buffer, great_lakes, how='difference')

--- a/src/run_by_unit.sh
+++ b/src/run_by_unit.sh
@@ -37,7 +37,7 @@ input_NLD=$inputDataDir/nld_vectors/huc2_levee_lines/nld_preprocessed_"$huc2Iden
 
 # Define the landsea water body mask using either Great Lakes or Ocean polygon input #
 if [[ $huc2Identifier == "04" ]] ; then
-  input_LANDSEA=$inputDataDir/landsea/gl_water_polygons.gpkg
+  input_LANDSEA=$input_GL_boundaries
   echo -e "Using $input_LANDSEA for water body mask (Great Lakes)"
 else
   input_LANDSEA=$inputDataDir/landsea/water_polygons_us.gpkg

--- a/src/run_by_unit.sh
+++ b/src/run_by_unit.sh
@@ -51,20 +51,12 @@ Tstart
 ogr2ogr -f GPKG $outputHucDataDir/wbd.gpkg $input_WBD_gdb $input_NHD_WBHD_layer -where "HUC$hucUnitLength='$hucNumber'"
 Tcount
 
-## BUFFER WBD ##
-echo -e $startDiv"Buffer WBD $hucNumber"$stopDiv
-date -u
-Tstart
-[ ! -f $outputHucDataDir/wbd_buffered.gpkg ] && \
-ogr2ogr -f GPKG -dialect sqlite -sql "select ST_buffer(geom, $wbd_buffer) from 'WBDHU$hucUnitLength'" $outputHucDataDir/wbd_buffered.gpkg $outputHucDataDir/wbd.gpkg
-Tcount
-
 ## Subset Vector Layers ##
 echo -e $startDiv"Get Vector Layers and Subset $hucNumber"$stopDiv
 date -u
 Tstart
 [ ! -f $outputHucDataDir/NHDPlusBurnLineEvent_subset.gpkg ] && \
-$srcDir/clip_vectors_to_wbd.py -d $hucNumber -w $input_nwm_flows -s $input_nhd_flowlines -l $input_nwm_lakes -r $input_NLD -g $outputHucDataDir/wbd.gpkg -f $outputHucDataDir/wbd_buffered.gpkg -m $input_nwm_catchments -y $input_nhd_headwaters -v $input_LANDSEA -c $outputHucDataDir/NHDPlusBurnLineEvent_subset.gpkg -z $outputHucDataDir/nld_subset_levees.gpkg -a $outputHucDataDir/nwm_lakes_proj_subset.gpkg -n $outputHucDataDir/nwm_catchments_proj_subset.gpkg -e $outputHucDataDir/nhd_headwater_points_subset.gpkg -b $outputHucDataDir/nwm_subset_streams.gpkg -x $outputHucDataDir/LandSea_subset.gpkg -extent $extent
+$srcDir/clip_vectors_to_wbd.py -d $hucNumber -w $input_nwm_flows -s $input_nhd_flowlines -l $input_nwm_lakes -r $input_NLD -g $outputHucDataDir/wbd.gpkg -f $outputHucDataDir/wbd_buffered.gpkg -m $input_nwm_catchments -y $input_nhd_headwaters -v $input_LANDSEA -c $outputHucDataDir/NHDPlusBurnLineEvent_subset.gpkg -z $outputHucDataDir/nld_subset_levees.gpkg -a $outputHucDataDir/nwm_lakes_proj_subset.gpkg -n $outputHucDataDir/nwm_catchments_proj_subset.gpkg -e $outputHucDataDir/nhd_headwater_points_subset.gpkg -b $outputHucDataDir/nwm_subset_streams.gpkg -x $outputHucDataDir/LandSea_subset.gpkg -extent $extent -gl $input_GL_boundaries -lb $lakes_buffer_dist_meters -wb $wbd_buffer
 Tcount
 
 if [ "$extent" = "MS" ]; then


### PR DESCRIPTION
Remove Great Lakes from wbd buffer. Resolves issue #374


## Changes

-The `gl_water_polygons.gpkg` layer is used to mask out Great Lakes boundaries and remove NHDPlus HR coastline segments. These segments are causing issues later in `run_by_unit.sh` and unnecessarily increasing total processing time.

The work done on this feature branch is mostly recycled from @RyanSpies-NOAA's feature branch `dev-ocean-mask-dem`.

## Testing

Resolves non-zero exit codes for MS Great Lakes HUCs. No errors with FR/MS non-Great Lakes HUCS

## Screenshots
FIM v3.0.15.9 MS streams for HUC 04040002
![image](https://user-images.githubusercontent.com/20129718/117054092-5f362300-acdf-11eb-9517-bf6c2a9bbcaa.png)


MS streams and catchments for HUC 04040002 with hotfix
![image](https://user-images.githubusercontent.com/20129718/117053430-8f30f680-acde-11eb-81aa-17a1ee9574a0.png)


## Notes

Geopandas (Shapely) buffer doesn't have the same precision as GDAL so there is a slight difference in the WBD buffer layer geometries. The buffer is set to 5000 m and should be well beyond the HUC extent and I changed the Shapely default buffer resolution so the difference is negligible though.



