### PR TITLE
[1pt] Bug fixes in preprocessing and run_test_case.py and update eval_plots (Dev-preprocess-ahps-fix)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,19 @@
 All notable changes to this project will be documented in this file.
 We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 <br/><br/>
+## v3.0.16.2 - 2021-05-18 - [PR #378](https://github.com/NOAA-OWP/cahaba/pull/378)
+
+Modifications and fixes to run_test_case.py, eval_plots.py, and ahps preprocessing scripts.
+
+## Changes
+- Comment out return statement causing run_test_case.py to skip over sites/hucs when calculating contingency rasters.
+- Pull bad sites list and query to filter out bad sites from metrics calculations to the tools_shared_variables.py
+- Add print statements in eval_plots.py detailing the bad sites used and the query used to filter out bad sites
+- Update ahps preprocessing scripts to produce a domain shapefile
+- Change output filenames produced in ahps preprocessing scripts
+- Update workarounds for some sites in ahps preprocessing scripts
+
+<br/><br/>
 ## v3.0.16.1 - 2021-05-11 - [PR #380](https://github.com/NOAA-OWP/cahaba/pull/380)
 
 The current version of Eventlet used in the Connector module of the FIM API is outdated and vulnerable. This update bumps the version to the patched version.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 All notable changes to this project will be documented in this file.
 We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 <br/><br/>
-## v3.0.16.2 - 2021-05-18 - [PR #378](https://github.com/NOAA-OWP/cahaba/pull/378)
+## v3.0.16.2 - 2021-05-18 - [PR #384](https://github.com/NOAA-OWP/cahaba/pull/384)
 
 Modifications and fixes to run_test_case.py, eval_plots.py, and ahps preprocessing scripts.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ Modifications and fixes to run_test_case.py, eval_plots.py, and ahps preprocessi
 
 ## Changes
 - Comment out return statement causing run_test_case.py to skip over sites/hucs when calculating contingency rasters.
-- Pull bad sites list and query to filter out bad sites from metrics calculations to the tools_shared_variables.py
+- Move bad sites list and query statement used to filter out bad sites to the tools_shared_variables.py
 - Add print statements in eval_plots.py detailing the bad sites used and the query used to filter out bad sites
 - Update ahps preprocessing scripts to produce a domain shapefile
 - Change output filenames produced in ahps preprocessing scripts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,17 +1,17 @@
 All notable changes to this project will be documented in this file.
 We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 <br/><br/>
-## v3.0.16.2 - 2021-05-18 - [PR #384](https://github.com/NOAA-OWP/cahaba/pull/384)
+## v3.0.16.2 - 2021-05-18 - [PR #384] (https://github.com/NOAA-OWP/cahaba/pull/384)
 
-Modifications and fixes to run_test_case.py, eval_plots.py, and ahps preprocessing scripts.
+Modifications and fixes to `run_test_case.py`, `eval_plots.py`, and AHPS preprocessing scripts.
 
 ## Changes
-- Comment out return statement causing run_test_case.py to skip over sites/hucs when calculating contingency rasters.
-- Move bad sites list and query statement used to filter out bad sites to the tools_shared_variables.py
-- Add print statements in eval_plots.py detailing the bad sites used and the query used to filter out bad sites
-- Update ahps preprocessing scripts to produce a domain shapefile
-- Change output filenames produced in ahps preprocessing scripts
-- Update workarounds for some sites in ahps preprocessing scripts
+- Comment out return statement causing `run_test_case.py` to skip over sites/hucs when calculating contingency rasters.
+- Move bad sites list and query statement used to filter out bad sites to the `tools_shared_variables.py`.
+- Add print statements in `eval_plots.py` detailing the bad sites used and the query used to filter out bad sites.
+- Update AHPS preprocessing scripts to produce a domain shapefile.
+- Change output filenames produced in ahps preprocessing scripts.
+- Update workarounds for some sites in ahps preprocessing scripts.
 
 <br/><br/>
 ## v3.0.16.1 - 2021-05-11 - [PR #380](https://github.com/NOAA-OWP/cahaba/pull/380)

--- a/tools/eval_plots.py
+++ b/tools/eval_plots.py
@@ -670,6 +670,6 @@ if __name__ == '__main__':
     i = args['site_plots']
 
     # Run eval_plots function
-    print('The following AHPS sites are discarded:  ' + ', '.join(BAD_SITES))
+    print('The following AHPS sites are considered "BAD_SITES":  ' + ', '.join(BAD_SITES))
     print('The following query is used to filter AHPS:  ' + DISCARD_AHPS_QUERY)
     eval_plots(metrics_csv = m, workspace = w, versions = v, stats = s, spatial = sp, fim_1_ms = f, site_barplots = i)

--- a/tools/eval_plots.py
+++ b/tools/eval_plots.py
@@ -481,8 +481,6 @@ def eval_plots(metrics_csv, workspace, versions = [], stats = ['CSI','FAR','TPR'
             base_resolution = 'nws_lid'
 
             # Filter the dataset based on query (IMPORTED FROM TOOLS_SHARED_VARIABLES.py)
-            print('The following AHPS sites are discarded:  ' + ', '.join(BAD_SITES))
-            print('The following query is used to filter AHPS:  ' + DISCARD_AHPS_QUERY)
             ahps_metrics = benchmark_metrics.query(DISCARD_AHPS_QUERY)
 
             # Filter out all instances where the base_resolution doesn't exist across all desired fim versions for a given magnitude
@@ -672,5 +670,6 @@ if __name__ == '__main__':
     i = args['site_plots']
 
     # Run eval_plots function
-
+    print('The following AHPS sites are discarded:  ' + ', '.join(BAD_SITES))
+    print('The following query is used to filter AHPS:  ' + DISCARD_AHPS_QUERY)
     eval_plots(metrics_csv = m, workspace = w, versions = v, stats = s, spatial = sp, fim_1_ms = f, site_barplots = i)

--- a/tools/eval_plots.py
+++ b/tools/eval_plots.py
@@ -14,6 +14,7 @@ sys.path.append('/foss_fim/src')
 from utils.shared_variables import VIZ_PROJECTION
 from dotenv import load_dotenv
 from tools_shared_functions import aggregate_wbd_hucs, get_metadata
+from tools_shared_variables import BAD_SITES, DISCARD_AHPS_QUERY
 
 #Get variables from .env file.
 load_dotenv()
@@ -338,7 +339,7 @@ def filter_dataframe(dataframe, unique_field):
 ##############################################################################
 #Main function to analyze metric csv.
 ##############################################################################
-def eval_plots(metrics_csv, workspace, versions = [], stats = ['CSI','FAR','TPR'] , alternate_ahps_query = False, spatial = False, fim_1_ms = False, site_barplots = False):
+def eval_plots(metrics_csv, workspace, versions = [], stats = ['CSI','FAR','TPR'] , spatial = False, fim_1_ms = False, site_barplots = False):
 
     '''
     Creates plots and summary statistics using metrics compiled from
@@ -411,10 +412,6 @@ def eval_plots(metrics_csv, workspace, versions = [], stats = ['CSI','FAR','TPR'
         A list of statistics to be plotted. Must be identical to column
         field in metrics_csv. CSI, POD, TPR are currently calculated, if
         additional statistics are desired formulas would need to be coded.
-    alternate_ahps_query : STRING, optional
-        The default is false. Currently the default ahps query is same
-        as done for apg goals. If a different query is desired it can be
-        supplied and it will supercede the default query.
     spatial : BOOL, optional
         Creates spatial datasets of the base unit (ble: huc polygon, ahps: point) 
         with metrics contained in attribute tables. The geospatial data is 
@@ -483,16 +480,10 @@ def eval_plots(metrics_csv, workspace, versions = [], stats = ['CSI','FAR','TPR'
             # Set the base processing unit for the ahps runs.
             base_resolution = 'nws_lid'
 
-            #Default query (used for APG) it could be that bad_sites should be modified. If so pass an alternate query using the "alternate_ahps_query"
-            bad_sites = ['grfi2','ksdm7','hohn4','rwdn4','efdn7','kilo1','chin7','segt2','eagi1','levk1','trbf1']
-            query = "not flow.isnull() & masked_perc<97 & not nws_lid in @bad_sites"
-
-            # If alternate ahps evaluation query argument is passed, use that.
-            if alternate_ahps_query:
-                query = alternate_ahps_query
-
-            # Filter the dataset based on query
-            ahps_metrics = benchmark_metrics.query(query)
+            # Filter the dataset based on query (IMPORTED FROM TOOLS_SHARED_VARIABLES.py)
+            print('The following AHPS sites are discarded:  ' + ', '.join(BAD_SITES))
+            print('The following query is used to filter AHPS:  ' + DISCARD_AHPS_QUERY)
+            ahps_metrics = benchmark_metrics.query(DISCARD_AHPS_QUERY)
 
             # Filter out all instances where the base_resolution doesn't exist across all desired fim versions for a given magnitude
             all_datasets[(benchmark_source, extent_configuration)] = filter_dataframe(ahps_metrics, base_resolution)
@@ -659,12 +650,11 @@ def eval_plots(metrics_csv, workspace, versions = [], stats = ['CSI','FAR','TPR'
 #######################################################################
 if __name__ == '__main__':
     # Parse arguments
-    parser = argparse.ArgumentParser(description = 'Plot and aggregate statistics for benchmark datasets (BLE/AHPS libraries)')
+    parser = argparse.ArgumentParser(description = f'Plot and aggregate statistics for benchmark datasets (BLE/AHPS libraries)')
     parser.add_argument('-m','--metrics_csv', help = 'Metrics csv created from synthesize test cases.', required = True)
     parser.add_argument('-w', '--workspace', help = 'Output workspace', required = True)
     parser.add_argument('-v', '--versions', help = 'List of versions to be plotted/aggregated. Versions are filtered using the "startswith" approach. For example, ["fim_","fb1"] would retain all versions that began with "fim_" (e.g. fim_1..., fim_2..., fim_3...) as well as any feature branch that began with "fb". An other example ["fim_3","fb"] would result in all fim_3 versions being plotted along with the fb.', nargs = '+', default = [])
     parser.add_argument('-s', '--stats', help = 'List of statistics (abbrev to 3 letters) to be plotted/aggregated', nargs = '+', default = ['CSI','TPR','FAR'], required = False)
-    parser.add_argument('-q', '--alternate_ahps_query',help = 'Alternate filter query for AHPS. Default is: "not nws_lid.isnull() & not flow.isnull() & masked_perc<97 & not nws_lid in @bad_sites" where bad_sites are (grfi2,ksdm7,hohn4,rwdn4)', default = False, required = False)
     parser.add_argument('-sp', '--spatial', help = 'If enabled, creates spatial layers with metrics populated in attribute table.', action = 'store_true', required = False)
     parser.add_argument('-f', '--fim_1_ms', help = 'If enabled fim_1 rows will be duplicated and extent config assigned "ms" so that fim_1 can be shown on mainstems plots/stats', action = 'store_true', required = False)
     parser.add_argument('-i', '--site_plots', help = 'If enabled individual barplots for each site are created.', action = 'store_true', required = False)
@@ -677,10 +667,10 @@ if __name__ == '__main__':
     w = args['workspace']
     v = args['versions']
     s = args['stats']
-    q = args['alternate_ahps_query']
     sp= args['spatial']
     f = args['fim_1_ms']
     i = args['site_plots']
 
     # Run eval_plots function
-    eval_plots(metrics_csv = m, workspace = w, versions = v, stats = s, alternate_ahps_query = q, spatial = sp, fim_1_ms = f, site_barplots = i)
+
+    eval_plots(metrics_csv = m, workspace = w, versions = v, stats = s, spatial = sp, fim_1_ms = f, site_barplots = i)

--- a/tools/preprocess_ahps_nws.py
+++ b/tools/preprocess_ahps_nws.py
@@ -96,6 +96,10 @@ def preprocess_nws(source_dir, destination, reference_raster):
             f.write(f'{code} : skipping because no rating curve source\n')
             continue
         
+        #Workaround for "bmbp1" where the only valid datum is from NRLDB (USGS datum is null). Modifying rating curve source will influence the rating curve and datum retrieved for benchmark determinations.
+        if code == 'bmbp1':
+            rating_curve_source = 'NRLDB'
+        
         #Get the datum and adjust to NAVD if necessary.
         nws, usgs = get_datum(metadata)
         datum_data = {}
@@ -115,6 +119,10 @@ def preprocess_nws(source_dir, destination, reference_raster):
         # Assumed to be NAD83 (no info from USGS or NWS data): dlrt2, eagi1, eppt2, jffw3, ldot2, rgdt2
         if code in ['bgwn7', 'dlrt2','eagi1','eppt2','fatw3','jffw3','ldot2','mnvn4','nhpp1','pinn4','rgdt2','rgln4','rssk1','sign4','smfn7','stkn4','wlln7' ]:
             datum_data.update(crs = 'NAD83')
+        
+        #Workaround for bmbp1; CRS supplied by NRLDB is mis-assigned (NAD29) and is actually NAD27. This was verified by converting USGS coordinates (in NAD83) for bmbp1 to NAD27 and it matches NRLDB coordinates.
+        if code == 'bmbp1':
+            datum_data.update(crs = 'NAD27')
         
         #Custom workaround these sites have poorly defined vcs from WRDS. VCS needed to ensure datum reported in NAVD88. If NGVD29 it is converted to NAVD88.
         #bgwn7, eagi1 vertical datum unknown, assume navd88

--- a/tools/preprocess_ahps_nws.py
+++ b/tools/preprocess_ahps_nws.py
@@ -226,7 +226,7 @@ def preprocess_nws(source_dir, destination, reference_raster):
                     #Create Binary Grids, first create domain of analysis, then create binary grid
                     
                     #Domain extent is largest floodmap in the static library WITH holes filled
-                    filled_domain_raster = outputdir.parent / f'{code}_domain.tif'
+                    filled_domain_raster = outputdir.parent / f'{code}_filled_orig_domain.tif'
     
                     #Open benchmark data as a rasterio object.
                     benchmark = rasterio.open(grid)
@@ -286,8 +286,11 @@ def preprocess_nws(source_dir, destination, reference_raster):
         #Wrapup for ahps sites that were processed.
         ahps_directory = destination / huc / code
         if ahps_directory.exists():
-            #Convert domain raster to shapefile.
-            filled_extent = ahps_directory / f'{code}_domain.tif' 
+            #Delete original filled domain raster (it is an intermediate file to create benchmark data)
+            orig_domain_grid = ahps_directory / f'{code}_filled_orig_domain.tif'
+            orig_domain_grid.unlink() 
+            #Create domain shapefile from any benchmark grid for site (each benchmark has domain footprint, value = 0).
+            filled_extent = list(ahps_directory.rglob('*_extent_*.tif'))[0]
             domain_gpd = raster_to_feature(grid = filled_extent, profile_override = False, footprint_only = True)           
             domain_gpd['nws_lid'] = code
             domain_gpd.to_file(ahps_directory / f'{code}_domain.shp')

--- a/tools/preprocess_ahps_usgs.py
+++ b/tools/preprocess_ahps_usgs.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-
 import numpy as np
 import pathlib
 from pathlib import Path
@@ -355,7 +354,7 @@ def preprocess_usgs(source_dir, destination, reference_raster):
                     #Create Binary Grids, first create domain of analysis, then create binary grid
                     
                     #Domain extent is largest floodmap in the static library WITH holes filled
-                    filled_domain_raster = outputdir.parent / f'{code}_extent.tif'
+                    filled_domain_raster = outputdir.parent / f'{code}_domain.tif'
                     #Create a domain raster if it does not exist.
                     if not filled_domain_raster.exists():
                         #Open extent data as rasterio object
@@ -377,7 +376,7 @@ def preprocess_usgs(source_dir, destination, reference_raster):
                                     
                     #Output binary benchmark grid and flow file to destination
                     outputdir.mkdir(parents = True, exist_ok = True)
-                    output_raster = outputdir / (f'ahps_{code}_huc_{huc}_depth_{i}.tif')
+                    output_raster = outputdir / (f'ahps_{code}_huc_{huc}_extent_{i}.tif')
                     with rasterio.Env():
                         with rasterio.open(output_raster, 'w', **boolean_profile) as dst:
                             dst.write(boolean_benchmark,1)
@@ -398,14 +397,14 @@ def preprocess_usgs(source_dir, destination, reference_raster):
             f.write(traceback.format_exc())
             f.write('\n')
             print(traceback.format_exc())
-        #Create extent if ahps code subfolder is present in destination directory.
+        #Wrapup for ahps sites that were processed.
         ahps_directory = destination / huc / code
         if ahps_directory.exists():
-            #Delete extent raster
-            filled_extent = ahps_directory / f'{code}_extent.tif' 
-            if filled_extent.exists:
-                filled_extent.unlink()            
-    
+            #Convert domain raster to shapefile.
+            filled_extent = ahps_directory / f'{code}_domain.tif' 
+            domain_gpd = raster_to_feature(grid = filled_extent, profile_override = False, footprint_only = True)           
+            domain_gpd['nws_lid'] = code
+            domain_gpd.to_file(ahps_directory / f'{code}_domain.shp')   
             #Populate attribute information for site
             grids_attributes = pd.DataFrame(data=grids.items(), columns = ['magnitude','path'])
             flows_attributes = pd.DataFrame(data=grid_flows.items(), columns=['magnitude','grid_flow_cfs'])

--- a/tools/preprocess_ahps_usgs.py
+++ b/tools/preprocess_ahps_usgs.py
@@ -354,7 +354,7 @@ def preprocess_usgs(source_dir, destination, reference_raster):
                     #Create Binary Grids, first create domain of analysis, then create binary grid
                     
                     #Domain extent is largest floodmap in the static library WITH holes filled
-                    filled_domain_raster = outputdir.parent / f'{code}_domain.tif'
+                    filled_domain_raster = outputdir.parent / f'{code}_filled_orig_domain.tif'
                     #Create a domain raster if it does not exist.
                     if not filled_domain_raster.exists():
                         #Open extent data as rasterio object
@@ -400,8 +400,11 @@ def preprocess_usgs(source_dir, destination, reference_raster):
         #Wrapup for ahps sites that were processed.
         ahps_directory = destination / huc / code
         if ahps_directory.exists():
-            #Convert domain raster to shapefile.
-            filled_extent = ahps_directory / f'{code}_domain.tif' 
+            #Delete original filled domain raster (it is an intermediate file to create benchmark data)
+            orig_domain_grid = ahps_directory / f'{code}_filled_orig_domain.tif'
+            orig_domain_grid.unlink()            
+            #Create domain shapefile from any benchmark grid for site (each benchmark has domain footprint, value = 0).
+            filled_extent = list(ahps_directory.rglob('*_extent_*.tif'))[0]
             domain_gpd = raster_to_feature(grid = filled_extent, profile_override = False, footprint_only = True)           
             domain_gpd['nws_lid'] = code
             domain_gpd.to_file(ahps_directory / f'{code}_domain.shp')   

--- a/tools/run_test_case.py
+++ b/tools/run_test_case.py
@@ -166,7 +166,7 @@ def run_alpha_test(fim_run_dir, version, test_id, magnitude, compare_to_previous
                     print(" ")
                 elif inundate_test == 1:
                     print (f"No matching feature IDs between forecast and hydrotable for magnitude: {magnitude}")
-                    return
+                    #return
             except Exception as e:
                 print(e)
 

--- a/tools/tools_shared_variables.py
+++ b/tools/tools_shared_variables.py
@@ -10,6 +10,20 @@ PRINTWORTHY_STATS = ['CSI', 'TPR', 'TNR', 'FAR', 'MCC', 'TP_area_km2', 'FP_area_
 GO_UP_STATS = ['CSI', 'TPR', 'MCC', 'TN_area_km2', 'TP_area_km2', 'TN_perc', 'TP_perc', 'TNR']
 GO_DOWN_STATS = ['FAR', 'FN_area_km2', 'FP_area_km2', 'FP_perc', 'FN_perc']
 
+# Variables for eval_plots.py
+BAD_SITES = ['grfi2',# Bad crosswalk from USGS to AHPS
+             'ksdm7',# Large areas entirely within levee protected area (CSI of 0)
+             'hohn4',# Mainstems did not extend far enough upstream
+             'rwdn4',# Mainstems did not extend far enough upstream.
+             'efdn7',# Limited upstream mapping
+             'kilo1',# Limited upstream mapping
+             'chin7',# Limited upstream mapping
+             'segt2',# Limited upstream mapping
+             'eagi1',# Missing large portions of FIM
+             'levk1',# Missing large portions of FIM
+             'trbf1']# Limited upstream mapping
+DISCARD_AHPS_QUERY = "not flow.isnull() & masked_perc<97 & not nws_lid in @BAD_SITES"
+
 # Colors.
 ENDC = '\033[m'
 TGREEN_BOLD = '\033[32;1m'


### PR DESCRIPTION
Collection of fixes and enhancements:
run_test_case.py --> comment out return statement that was causing inundation.py to skip over certain sites
AHPS preprocessing scripts --> update edge case scenarios/workarounds and update output filenames
eval_plots.py --> Pull the bad_sites list and the query used to filter out ahps sites to discard into the tools_shared_variables.py

These address tickets #381, #369, #326, #385, #377
## Removals

- Return statement in run_test_case

## Changes

- Edits to custom workarounds for preprocessing ahps data
- Move the list of bad sites and the query used to filter out bad ahps locations to tools_shared_variables.py

## Testing

1. To test you can run synthesize test cases, there should be "minor","moderate","major" subfolders in 02030103
2. Run eval_plots.py and it will defer to the tools_shared_variables.py to retrieve the bad_sites list and the query to remove the bad sites.
