### PR TITLE
[8pt] PR: Correct headwater assignment nws_lid layer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,9 @@
 All notable changes to this project will be documented in this file.
 We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 <br/><br/>
-## v3.0.16.5 - 2021-05-25 - [PR #395](https://github.com/NOAA-OWP/cahaba/pull/395)
+## v3.0.XX.X - 2021-05-XX - [PR #395](https://github.com/NOAA-OWP/cahaba/pull/395)
 
-Fix incorrectly assigned attributes in nws_lid.gpkg layer created from the "generate_nws_lid.py" script
+Bug fix to the `generate_nws_lid.py` script
 
 ## Changes
 - Fixes incorrectly assigned attribute field "is_headwater" for some sites in the nws_lid.gpkg layer.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,8 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 Bug fix to the `generate_nws_lid.py` script
 
 ## Changes
-- Fixes incorrectly assigned attribute field "is_headwater" for some sites in the nws_lid.gpkg layer.
-- updated `agg_nhd_headwaters_adj.gpkg`, `agg_nhd_streams_adj.gpkg`, `nwm_flows.gpkg`, and `nwm_catchments.gpkg` input layers using latest NWS LIDs.
+- Fixes incorrectly assigned attribute field "is_headwater" for some sites in the `nws_lid.gpkg` layer.
+- Updated `agg_nhd_headwaters_adj.gpkg`, `agg_nhd_streams_adj.gpkg`, `nwm_flows.gpkg`, and `nwm_catchments.gpkg` input layers using latest NWS LIDs.
 
 <br/><br/>
 ## v3.0.17.0 - 2021-06-04 - [PR #393](https://github.com/NOAA-OWP/cahaba/pull/393)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Bug fix to the `generate_nws_lid.py` script
 
 ## Changes
 - Fixes incorrectly assigned attribute field "is_headwater" for some sites in the nws_lid.gpkg layer.
+- updated `agg_nhd_headwaters_adj.gpkg`, `agg_nhd_streams_adj.gpkg`, `nwm_flows.gpkg`, and `nwm_catchments.gpkg` input layers using latest NWS LIDs.
 
 <br/><br/>
 ## v3.0.17.0 - 2021-06-04 - [PR #393](https://github.com/NOAA-OWP/cahaba/pull/393)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@ All notable changes to this project will be documented in this file.
 We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 <br/><br/>
 
+## v3.0.17.1 - 2021-06-04 - [PR #395](https://github.com/NOAA-OWP/cahaba/pull/395)
+
+Bug fix to the `generate_nws_lid.py` script
+
+## Changes
+- Fixes incorrectly assigned attribute field "is_headwater" for some sites in the nws_lid.gpkg layer.
+
+<br/><br/>
 ## v3.0.17.0 - 2021-06-04 - [PR #393](https://github.com/NOAA-OWP/cahaba/pull/393)
 BARC updates to cap the bathy calculated xsec area in `bathy_rc_adjust.py` and allow user to choose input bankfull geometry.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,6 @@
 All notable changes to this project will be documented in this file.
 We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 <br/><br/>
-## v3.0.17.1 - 2021-06-04 - [PR #395](https://github.com/NOAA-OWP/cahaba/pull/395)
-
-Bug fix to the `generate_nws_lid.py` script
-
-## Changes
-- Fixes incorrectly assigned attribute field "is_headwater" for some sites in the nws_lid.gpkg layer.
-
-<br/><br/>
 
 ## v3.0.17.0 - 2021-06-04 - [PR #393](https://github.com/NOAA-OWP/cahaba/pull/393)
 BARC updates to cap the bathy calculated xsec area in `bathy_rc_adjust.py` and allow user to choose input bankfull geometry.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,25 @@
 All notable changes to this project will be documented in this file.
 We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 <br/><br/>
-## v3.0.XX.X - 2021-05-XX - [PR #395](https://github.com/NOAA-OWP/cahaba/pull/395)
+## v3.0.17.1 - 2021-06-04 - [PR #395](https://github.com/NOAA-OWP/cahaba/pull/395)
 
 Bug fix to the `generate_nws_lid.py` script
 
 ## Changes
 - Fixes incorrectly assigned attribute field "is_headwater" for some sites in the nws_lid.gpkg layer.
+
+<br/><br/>
+
+## v3.0.17.0 - 2021-06-04 - [PR #393](https://github.com/NOAA-OWP/cahaba/pull/393)
+BARC updates to cap the bathy calculated xsec area in `bathy_rc_adjust.py` and allow user to choose input bankfull geometry.
+
+## Changes
+
+- Added new env variable to control which input file is used for the bankfull geometry input to bathy estimation workflow.
+- Modified the bathymetry cross section area calculation to cap the additional area value so that it cannot exceed the bankfull cross section area value for each stream segment (bankfull value obtained from regression equation dataset).
+- Modified the `rating_curve_comparison.py` plot output to always put the FIM rating curve on top of the USGS rating curve (avoids USGS points covering FIM).
+- Created a new aggregate csv file (aggregates for all hucs) for all of the `usgs_elev_table.csv` files (one per huc).
+- Evaluate the FIM Bathymetry Adjusted Rating Curve (BARC) tool performance using the estimated bankfull geometry dataset derived for the NWM route link dataset.
 
 <br/><br/>
 ## v3.0.16.3 - 2021-05-21 - [PR #388](https://github.com/NOAA-OWP/cahaba/pull/388)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,14 @@
 All notable changes to this project will be documented in this file.
 We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 <br/><br/>
+## v3.0.16.5 - 2021-05-25 - [PR #395](https://github.com/NOAA-OWP/cahaba/pull/395)
 
+Fix incorrectly assigned attributes in nws_lid.gpkg layer created from the "generate_nws_lid.py" script
+
+## Changes
+- Fixes incorrectly assigned attribute field "is_headwater" for some sites in the nws_lid.gpkg layer.
+
+<br/><br/>
 ## v3.0.16.3 - 2021-05-21 - [PR #388](https://github.com/NOAA-OWP/cahaba/pull/388)
 
 Enhancement and bug fixes to `synthesize_test_cases.py`.

--- a/fim_run.sh
+++ b/fim_run.sh
@@ -114,8 +114,8 @@ export input_WBD_gdb=$inputDataDir/wbd/WBD_National.gpkg
 export input_nwm_lakes=$inputDataDir/nwm_hydrofabric/nwm_lakes.gpkg
 export input_nwm_catchments=$inputDataDir/nwm_hydrofabric/nwm_catchments.gpkg
 export input_nwm_flows=$inputDataDir/nwm_hydrofabric/nwm_flows.gpkg
-export input_nhd_flowlines=$inputDataDir/nhdplus_vectors_aggregate/agg_nhd_streams_adj.gpkg
-export input_nhd_headwaters=$inputDataDir/nhdplus_vectors_aggregate/agg_nhd_headwaters_adj.gpkg
+export input_nhd_flowlines=$inputDataDir/nhdplus_vectors_aggregate/agg_nhd_streams_adj_new.gpkg
+export input_nhd_headwaters=$inputDataDir/nhdplus_vectors_aggregate/agg_nhd_headwaters_adj_new.gpkg
 export input_GL_boundaries=$inputDataDir/landsea/gl_water_polygons.gpkg
 ## Input handling ##
 $srcDir/check_huc_inputs.py -u "$hucList"

--- a/fim_run.sh
+++ b/fim_run.sh
@@ -114,8 +114,8 @@ export input_WBD_gdb=$inputDataDir/wbd/WBD_National.gpkg
 export input_nwm_lakes=$inputDataDir/nwm_hydrofabric/nwm_lakes.gpkg
 export input_nwm_catchments=$inputDataDir/nwm_hydrofabric/nwm_catchments.gpkg
 export input_nwm_flows=$inputDataDir/nwm_hydrofabric/nwm_flows.gpkg
-export input_nhd_flowlines=$inputDataDir/nhdplus_vectors_aggregate/agg_nhd_streams_adj_new.gpkg
-export input_nhd_headwaters=$inputDataDir/nhdplus_vectors_aggregate/agg_nhd_headwaters_adj_new.gpkg
+export input_nhd_flowlines=$inputDataDir/nhdplus_vectors_aggregate/agg_nhd_streams_adj.gpkg
+export input_nhd_headwaters=$inputDataDir/nhdplus_vectors_aggregate/agg_nhd_headwaters_adj.gpkg
 export input_GL_boundaries=$inputDataDir/landsea/gl_water_polygons.gpkg
 ## Input handling ##
 $srcDir/check_huc_inputs.py -u "$hucList"

--- a/tools/generate_nws_lid.py
+++ b/tools/generate_nws_lid.py
@@ -127,10 +127,12 @@ def generate_nws_lid(workspace):
             [to_node] = network[from_node]
             #Walk downstream from target
             while to_node>0:
-                [to_node] = network[to_node]
                 #Check if to_node is in targets list
                 if to_node in targets:
-                    sub_dict[to_node] = 'not_headwater'    
+                    sub_dict[to_node] = 'not_headwater'  
+                #Assign downstream ID as to_node
+                [to_node] = network[to_node]
+  
         #Append status to master dictionary
         all_dicts.update(sub_dict)
     


### PR DESCRIPTION
The nws_lid layer is_headwater field incorrectly attributed if an ahps location was immediately downstream of an actual headwater point.  This has been corrected and it appears to affect 35 of 4,000+ sites. This addresses issue #383 and issue #397.

## Changes

- Fix incorrect classification of headwater status for some sites in the nws_lid.gpkg layer.

## Testing

1. run the "generate_nws_lid.py" script

## Screenshots
LCAT2 is not assigned as a headwater (red dots)
![image](https://user-images.githubusercontent.com/69653333/119530086-4baf3280-bd48-11eb-9d20-4e67360014c7.png)
WOBT2 not assigned as a headwater (red dots)
![image](https://user-images.githubusercontent.com/69653333/119530175-64b7e380-bd48-11eb-8f2e-8cf367ec620d.png)
EMIU1 is correctly assigned as headwater (red dots) and RBCU1, RBRU1, CCSU1 are correctly classified as not_headwaters.
![image](https://user-images.githubusercontent.com/69653333/119532242-536fd680-bd4a-11eb-899a-b58b3beb51cf.png)




