### PR TITLE
Update taudemVersion

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -4,7 +4,7 @@ WORKDIR /opt/builder
 ARG dataDir=/data
 ARG projectDir=/foss_fim
 ARG depDir=/dependencies
-ARG taudemVersion=bf9417172225a9ce2462f11138c72c569c253a1a
+ARG taudemVersion=8519cf0c61d280945473491d51ba368196146ce0
 ARG taudemVersion2=81f7a07cdd3721617a30ee4e087804fddbcffa88
 ENV DEBIAN_FRONTEND noninteractive
 ENV taudemDir=$depDir/taudem/bin

--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -4,7 +4,7 @@ WORKDIR /opt/builder
 ARG dataDir=/data
 ARG projectDir=/foss_fim
 ARG depDir=/dependencies
-ARG taudemVersion=bf9417172225a9ce2462f11138c72c569c253a1a
+ARG taudemVersion=8519cf0c61d280945473491d51ba368196146ce0
 ARG taudemVersion2=81f7a07cdd3721617a30ee4e087804fddbcffa88
 ENV DEBIAN_FRONTEND noninteractive
 ENV taudemDir=$depDir/taudem/bin


### PR DESCRIPTION
Update taudemVersion in Dockerfile.dev and Dockerfile.prod

Fixes the following error during `docker build --no-cache -f Dockerfile.dev -t cahaba .`:

`Step 16/49 : RUN cd taudem     && git checkout $taudemVersion     && cd src     && make
 ---> Running in b0baed53683c
fatal: reference is not a tree: bf9417172225a9ce2462f11138c72c569c253a1a
The command '/bin/sh -c cd taudem     && git checkout $taudemVersion     && cd src     && make' returned a non-zero code: 128`
