### PR TITLE
PR: Adding line to check for NWM stream segments within HUC boundaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@ All notable changes to this project will be documented in this file.
 We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 <br/><br/>
 
+## v3.0.20.1 - 2021-08-13 - [PR #443](https://github.com/NOAA-OWP/cahaba/pull/443)
+
+This merge modifies `clip_vectors_to_wbd.py` to check for relevant data.
+
+## Changes
+- `clip_vectors_to_wbd.py` now checks that there are NWM stream segments within the buffered HUC boundary.
+
+<br/><br/>
+
 ## v3.0.20.0 - 2021-08-11 - [PR #440](https://github.com/NOAA-OWP/cahaba/pull/440)
 
 This merge adds two new scripts into `/tools/` for use in QAQC.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ This merge modifies `clip_vectors_to_wbd.py` to check for relevant data.
 
 ## Changes
 - `clip_vectors_to_wbd.py` now checks that there are NWM stream segments within the buffered HUC boundary.
-- `included_huc8_ms.lst` has several attional HUC8s.
+- `included_huc8_ms.lst` has several additional HUC8s.
 
 <br/><br/>
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This merge modifies `clip_vectors_to_wbd.py` to check for relevant data.
 
 ## Changes
 - `clip_vectors_to_wbd.py` now checks that there are NWM stream segments within the buffered HUC boundary.
+- `included_huc8_ms.lst` has several attional HUC8s.
 
 <br/><br/>
 

--- a/src/clip_vectors_to_wbd.py
+++ b/src/clip_vectors_to_wbd.py
@@ -127,7 +127,11 @@ def subset_vector_layers(hucCode,nwm_streams_filename,nhd_streams_filename,nwm_l
     nwm_streams = gpd.read_file(nwm_streams_filename, mask = wbd_buffer)
     if extent == 'MS':
         nwm_streams = nwm_streams.loc[nwm_streams.mainstem==1]
-    nwm_streams.to_file(subset_nwm_streams_filename,driver=getDriver(subset_nwm_streams_filename),index=False)
+    if len(nwm_streams) > 0:
+        nwm_streams.to_file(subset_nwm_streams_filename,driver=getDriver(subset_nwm_streams_filename),index=False)
+    else:
+        print ("No NWM stream segments within HUC " + str(hucCode) +  " boundaries.")
+        sys.exit(0)
     del nwm_streams
 
 if __name__ == '__main__':


### PR DESCRIPTION
After reviewing the outputs of the last release I noticed that there needed to be a checkpoint in `clip_vectors_to_wbd.py` to make sure that the HUC contained NWM stream segments. This applies mostly to the MS extent where there is not necessarily NWM forecasting in every HUC8. 

There should be no change to the outputs from this checkpoint. 

In addition several more HUC8s have been added to the MS extent list providing complete coverage of the MS NWM domain.