### PR TITLE
[1pt] PR: Patch updater.py after BARC merge

### DIFF
--- a/api/node/updater/updater.py
+++ b/api/node/updater/updater.py
@@ -454,7 +454,7 @@ def ws_add_job_to_queue(data):
         hucs = data['hucs']
         extent = data['extent']
         branch = 'dev'
-        config_path = './foss_fim/config/params_calibrated.env'
+        config_path = './foss_fim/config/params_template.env'
         dev_run = False
         viz_run = True
         previous_major_fim_version = data['previous_major_fim_version']

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,7 +6,7 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 Patches the API updater. The `params_calibrated.env` is replaced with `params_template.env` because the BARC and Multi-N modules supplant the calibrated values.
 
 ## Changes
-- `api/node/updater/updater.py`: Changed `params_calibrated.env` to `params_template.py`
+- `api/node/updater/updater.py`: Changed `params_calibrated.env` to `params_template.env`
 
 <br/><br/>
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,14 @@ All notable changes to this project will be documented in this file.
 We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 <br/><br/>
 
+## v3.0.23.1 - 2021-11-03 - [PR #479](https://github.com/NOAA-OWP/cahaba/pull/479)
+Patches the API updater. The `params_calibrated.env` is replaced with `params_template.env` because the BARC and Multi-N modules supplant the calibrated values.
+
+## Changes
+- `api/node/updater/updater.py`: Changed `params_calibrated.env` to `params_template.py`
+
+<br/><br/>
+
 ## v3.0.23.0 - 2021-10-31 - [PR #475](https://github.com/NOAA-OWP/cahaba/pull/475)
 
 Moved the synthetic rating curve (SRC) processes from the `\tools` directory to `\src` directory to support post-processing in `fim_run.sh`. These SRC post-processing modules will now run as part of the default `fim_run.sh` workflow. Reconfigured bathymetry adjusted rating curve (BARC) module to use the 1.5yr flow from NWM v2 recurrence flow data in combination with the Bieger et al. (2015) regression equations with bankfull discharge predictor variable input.


### PR DESCRIPTION
Change API for release runs to use `params_template` instead of `params_calibrated`

## Changes

-`api/node/updater/updater.py`: Changed `params_calibrated.env` to `params_template.env` 

