### PR TITLE
[1pt] PR: Adds ability to create a GPKG with joined rating curve comparison statistics

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,12 +1,25 @@
 All notable changes to this project will be documented in this file.
 We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 
+## v3.0.24.5 - 2021-12-10 - [PR #493](https://github.com/NOAA-OWP/cahaba/pull/493)
+
+This merge adds the functionality to create a geopackage with a point layer whose attribute table includes statistical comparison between SRCs and USGS rating curves.
+
+## Changes
+- `/tools/rating_curve_comparison.py`: 
+    - updated recurrence intervals to reflect newest 17C run: 2, 5, 10, 25, 50, 100
+    - added `create_static_gpkg()` function which is called when the optional `--stat_gages` option is passed and will create a GPKG that joins a USGS gage dataset with the Sierra Test statistics
+- `/tools/rating_curve_get_usgs_gages.py`: bug fixes and added simple progress indicator for gage requests and metadata processing
+- `/tools/tools_shared_functions.py`: added `requests_get_with_retry()` function that is a wrapper for the requests to API calls that will retry and wait if the response is throttled
+
+<br/><br/>
+
 ## v3.0.24.4 - 2021-12-03 - [PR #491](https://github.com/NOAA-OWP/cahaba/pull/491)
 
 Adds Probability Not Detected (PND) as metric to evaluation code.
 
 ## Changes
- - `synthesize_test_cases.py`: added `PND` into the dictionary of searched metrics.
+- `synthesize_test_cases.py`: added `PND` into the dictionary of searched metrics.
 - `tool_shared_variables.py`: added `PND` to the `GO_DOWN_STATS` list variable.
 - `tools_shared_functions.py`: added the `PND` calculation and inclusion into stats_dictionary.
 - `eval_plots.py`: added automatic plotting of `PND` and inclusion in spatial outputs. Also updated an argument in matplotlib call (I changed `b` to `visible`) in accordance with matplotlib recommendations concerning an impending deprecation of `b`.

--- a/tools/rating_curve_comparison.py
+++ b/tools/rating_curve_comparison.py
@@ -420,6 +420,8 @@ def create_static_gpkg(output_dir, output_gpkg, agg_recurr_stats_table, gages_gp
     sns.countplot(ax=ax[1,1], y='mean_y_diff_ft', data=usgs_gages)
     sns.boxplot(ax=ax[0,1], data=usgs_gages[['2', '5', '10', '25', '50', '100', 'action', 'minor', 'moderate','major']])
     ax[0,1].set(ylim=(-12, 12))
+
+    fig.tight_layout()
     fig.savefig(join(output_dir, f'{output_gpkg}_summary_plots.png'.replace('.gpkg', '')))
 
     return

--- a/tools/rating_curve_comparison.py
+++ b/tools/rating_curve_comparison.py
@@ -411,8 +411,14 @@ def create_static_gpkg(output_dir, output_gpkg, agg_recurr_stats_table, gages_gp
     fig, ax = plt.subplots(2, 2, figsize=(18, 10))
 
     # Bin data
-    usgs_gages['mean_abs_y_diff_ft'] = pd.cut(usgs_gages['mean_abs_y_diff_ft'], bins=(0, 1, 3, 6, 9, usgs_gages['mean_abs_y_diff_ft'].max()))
-    usgs_gages['mean_y_diff_ft'] = pd.cut(usgs_gages['mean_y_diff_ft'], bins=(usgs_gages['mean_y_diff_ft'].min(),-9, -6, -3, -1, 0, 1, 3, 6, 9, usgs_gages['mean_y_diff_ft'].max()))
+    max_bin = usgs_gages['mean_abs_y_diff_ft'].max()
+    bins = (0, 1, 3, 6, 9, max_bin if max_bin > 12 else 12)
+    usgs_gages['mean_abs_y_diff_ft'] = pd.cut(usgs_gages['mean_abs_y_diff_ft'], bins=bins)
+    
+    max_bin = usgs_gages['mean_y_diff_ft'].max()
+    min_bin = usgs_gages['mean_y_diff_ft'].min()
+    bins = (min_bin if min_bin < -12 else -12, -9, -6, -3, -1, 0, 1, 3, 6, 9, max_bin if max_bin > 12 else 12)
+    usgs_gages['mean_y_diff_ft'] = pd.cut(usgs_gages['mean_y_diff_ft'], bins=bins)
 
     # Create subplots
     sns.histplot(ax=ax[0,0], y='nrmse', data=usgs_gages, binwidth=0.2, binrange=(0, 10))

--- a/tools/rating_curve_get_usgs_curves.py
+++ b/tools/rating_curve_get_usgs_curves.py
@@ -132,8 +132,10 @@ def write_categorical_flow_files(metadata, workspace):
     workspace.mkdir(parents = True, exist_ok = True)
     #For each site in metadata 
     all_data = pd.DataFrame()
+    i = 1
     
     for site in metadata:
+        print(f' {i} / {len(metadata)}', end='\r'); i+=1
         #Get the feature_id and usgs_site_code
         feature_id = site.get('identifiers').get('nwm_feature_id')
         usgs_code = site.get('identifiers').get('usgs_site_code')
@@ -262,9 +264,12 @@ def usgs_rating_to_elev(list_of_gage_sites, workspace=False, sleep_time = 1.0):
     all_rating_curves = pd.DataFrame()
     regular_messages = []    
     api_failure_messages=[]
+    i = 1
     #For each site in metadata_list
     for metadata in metadata_list:
         
+        print(f' {i} / {len(metadata_list)}', end='\r'); i+=1
+
         #Get datum information for site (only need usgs_data)
         nws, usgs = get_datum(metadata)        
         
@@ -319,6 +324,7 @@ def usgs_rating_to_elev(list_of_gage_sites, workspace=False, sleep_time = 1.0):
         #Append all rating curves to a dataframe
         all_rating_curves = all_rating_curves.append(curve)        
 
+    import pdb; pdb.set_trace()
     #Rename columns and add attribute indicating if rating curve exists
     acceptable_sites_gdf.rename(columns = {'nwm_feature_id':'feature_id','usgs_site_code':'location_id'}, inplace = True)
     sites_with_data = pd.DataFrame({'location_id':all_rating_curves['location_id'].unique(),'curve':'yes'})

--- a/tools/rating_curve_get_usgs_curves.py
+++ b/tools/rating_curve_get_usgs_curves.py
@@ -324,7 +324,6 @@ def usgs_rating_to_elev(list_of_gage_sites, workspace=False, sleep_time = 1.0):
         #Append all rating curves to a dataframe
         all_rating_curves = all_rating_curves.append(curve)        
 
-    import pdb; pdb.set_trace()
     #Rename columns and add attribute indicating if rating curve exists
     acceptable_sites_gdf.rename(columns = {'nwm_feature_id':'feature_id','usgs_site_code':'location_id'}, inplace = True)
     sites_with_data = pd.DataFrame({'location_id':all_rating_curves['location_id'].unique(),'curve':'yes'})

--- a/tools/tools_shared_functions.py
+++ b/tools/tools_shared_functions.py
@@ -1068,15 +1068,15 @@ def ngvd_to_navd_ft(datum_info, region = 'contiguous'):
     
     #Define parameters. Hard code most parameters to convert NGVD to NAVD.    
     params = {}
-    params['lat'] = round(lat, 6)
-    params['lon'] = round(lon, 6)
-    params['region'] = region
+    params['lat']       = round(lat, 6)
+    params['lon']       = round(lon, 6)
+    params['region']    = region
     params['s_h_frame'] = 'NAD27'     #Source CRS
     params['s_v_frame'] = 'NGVD29'    #Source vertical coord datum
-    params['s_vertical_unit'] = 'm'   #Source vertical units
-    params['src_height'] = 0.0        #Source vertical height
+    params['s_v_unit']  = 'm'         #Source vertical units
+    params['height']    = 0.0         #Source vertical height
     params['t_v_frame'] = 'NAVD88'    #Target vertical datum
-    params['tar_vertical_unit'] = 'm' #Target vertical height
+    params['t_v_unit '] = 'm'         #Target vertical height
     
     #Call the API
     response = requests.get(datum_url, params = params)

--- a/tools/tools_shared_functions.py
+++ b/tools/tools_shared_functions.py
@@ -895,7 +895,7 @@ def get_thresholds(threshold_url, select_by, selector, threshold = 'all'):
     params['threshold'] = threshold
     url = f'{threshold_url}/{select_by}/{selector}'
     # Query WRDS
-    response = requests_get_with_retry(url, params=params)
+    response = requests_get_with_retry(url, url_params=params)
 
     if response.ok:
         thresholds_json = response.json()
@@ -1107,7 +1107,7 @@ def ngvd_to_navd_ft(datum_info, region = 'contiguous'):
     params['t_v_unit '] = 'm'         #Target vertical height
     
     #Call the API
-    response = requests_get_with_retry(datum_url, params=params)
+    response = requests_get_with_retry(datum_url, url_params=params)
 
     #If succesful get the navd adjustment
     if response:

--- a/tools/tools_shared_functions.py
+++ b/tools/tools_shared_functions.py
@@ -1068,8 +1068,8 @@ def ngvd_to_navd_ft(datum_info, region = 'contiguous'):
     
     #Define parameters. Hard code most parameters to convert NGVD to NAVD.    
     params = {}
-    params['lat'] = lat
-    params['lon'] = lon
+    params['lat'] = round(lat, 6)
+    params['lon'] = round(lon, 6)
     params['region'] = region
     params['s_h_frame'] = 'NAD27'     #Source CRS
     params['s_v_frame'] = 'NGVD29'    #Source vertical coord datum


### PR DESCRIPTION
This merge adds the functionality to create a geopackage with a point layer whose attribute table includes statistical comparison between SRCs and USGS rating curves.

## Changes

- `/tools/rating_curve_comparison.py`: 
    - updated recurrence intervals to reflect newest 17C run: 2, 5, 10, 25, 50, 100
    - added `create_static_gpkg()` function which is called when the optional `--stat_gages` option is passed and will create a GPKG that joins a USGS gage dataset with the Sierra Test statistics
- `/tools/rating_curve_get_usgs_gages.py`: bug fixes and added simple progress indicator for gage requests and metadata processing
- `/tools/tools_shared_functions.py`: added `requests_get_with_retry()` function that is a wrapper for the requests to API calls that will retry and wait if the response is throttled

## Testing

To test, you can look at the attribute table for `/tools/sierra_test/testing_versions/fim_3_0_24_2/usgs_gages_stats.gpkg` to confirm that the statistics have joined successfully with the gage dataset. There is a PNG with the same name that includes summary plots for each statistic.

You can also run the Sierra Test using the argument `-pnts /inputs/usgs_gages/usgs_gages.gpkg usgs_gages.stats.gpkg`. The `-pnts` accepts 2 arguments: 1) input USGS gage geopackage and 2) the output geopackage name, which will be written in the same output directory specified in the `-output_dir` argument.

![usgs_gages_stats gpkg_summary_plots](https://user-images.githubusercontent.com/90792257/145612629-c87a1bf1-2f7e-4dff-b775-8d9c89660c51.png)



