### PR TITLE
[1pt] PR: refinements to usgs_gage_crosswalk.py

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,6 +1,17 @@
 All notable changes to this project will be documented in this file.
 We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 
+## v3.0.24.8 - 2022-01-12 - [PR #503](https://github.com/NOAA-OWP/cahaba/pull/503)
+
+This pull request adds an additional feature_id attribute associated with USGS gage locations (feature_id obtained from the WRDS API) output in the `usgs_gage_crosswalk.py`. There is also a new USGS gage query to ensure gage's HUC8 matches the FIM HUC when performing the gage-huc spatial query (avoids duplicating gages in multiple HUCs).
+
+## Changes
+- `src/run_by_unit.sh`: updated to include the HUC8 id as an input argument to `usgs_gage_crosswalk.py` when running `fim_run.sh`
+- `usgs_gage_crosswalk.py`: updated to include both `feature_id` (HAND-FIM crosswalked feature_id) and `feature_id_wrds` (feature_id assoicated with USGS gage location obtained from WRDS API). Also included the `gage_distance_to_line` attribute to potentially identify issues with correlating gage locations to the nearest thalweg pixel.
+
+<br/><br/>
+
+
 ## v3.0.24.7 - 2021-12-30 - [PR #500](https://github.com/NOAA-OWP/cahaba/pull/500)
 
 Update API Release Branch

--- a/src/run_by_unit.sh
+++ b/src/run_by_unit.sh
@@ -407,7 +407,7 @@ Tcount
 echo -e $startDiv"USGS Crosswalk $hucNumber"$stopDiv
 date -u
 Tstart
-python3 -m memory_profiler $srcDir/usgs_gage_crosswalk.py -gages $inputDataDir/usgs_gages/usgs_gages.gpkg -dem $outputHucDataDir/dem_meters.tif -flows $outputHucDataDir/demDerived_reaches_split_filtered_addedAttributes_crosswalked.gpkg -cat $outputHucDataDir/gw_catchments_reaches_filtered_addedAttributes_crosswalked.gpkg -wbd $outputHucDataDir/wbd_buffered.gpkg -dem_adj $dem_thalwegCond -outtable $outputHucDataDir/usgs_elev_table.csv -e $extent
+python3 -m memory_profiler $srcDir/usgs_gage_crosswalk.py -gages $inputDataDir/usgs_gages/usgs_gages.gpkg -dem $outputHucDataDir/dem_meters.tif -flows $outputHucDataDir/demDerived_reaches_split_filtered_addedAttributes_crosswalked.gpkg -cat $outputHucDataDir/gw_catchments_reaches_filtered_addedAttributes_crosswalked.gpkg -wbd $outputHucDataDir/wbd_buffered.gpkg -dem_adj $dem_thalwegCond -outtable $outputHucDataDir/usgs_elev_table.csv -e $extent -huc $hucNumber
 Tcount
 
 ## CLEANUP OUTPUTS ##

--- a/src/usgs_gage_crosswalk.py
+++ b/src/usgs_gage_crosswalk.py
@@ -33,33 +33,36 @@ warnings.simplefilter("ignore")
 
 
 @mem_profile
-def crosswalk_usgs_gage(usgs_gages_filename,dem_filename,input_flows_filename,input_catchment_filename,wbd_buffer_filename,dem_adj_filename,output_table_filename,extent):
+def crosswalk_usgs_gage(usgs_gages_filename,dem_filename,input_flows_filename,input_catchment_filename,wbd_buffer_filename,dem_adj_filename,output_table_filename,extent,huc8):
 
     wbd_buffer = gpd.read_file(wbd_buffer_filename)
-    usgs_gages = gpd.read_file(usgs_gages_filename, mask=wbd_buffer)
+    usgs_gages = gpd.read_file(usgs_gages_filename, mask=wbd_buffer, dtype={'huc': object})
     dem_m = rasterio.open(dem_filename,'r')
     input_flows = gpd.read_file(input_flows_filename)
     input_catchment = gpd.read_file(input_catchment_filename)
     dem_adj = rasterio.open(dem_adj_filename,'r')
 
-    #MS extent use gages that are mainstem
+    #MS extent use gages that are mainstem & match huc8 id
     if extent == "MS":
         usgs_gages = usgs_gages.query('curve == "yes" & mainstem == "yes"')
-    #FR extent use gages that are not mainstem
+        usgs_gages = usgs_gages[usgs_gages.HUC8 == huc8]
+    #FR extent use gages that are not mainstem & match huc8 id
     if extent == "FR":
         usgs_gages = usgs_gages.query('curve == "yes" & mainstem == "no"')
+        usgs_gages = usgs_gages[usgs_gages.HUC8 == huc8]
 
     if input_flows.HydroID.dtype != 'int': input_flows.HydroID = input_flows.HydroID.astype(int)
 
     # Identify closest HydroID
+    usgs_gages.rename(columns={'feature_id':'feature_id_wrds'}, inplace=True)# rename feature_id attribute from USGS gages (obtained from WRDS api)
     closest_catchment = gpd.sjoin(usgs_gages, input_catchment, how='left', op='within').reset_index(drop=True)
-    closest_hydro_id = closest_catchment.filter(items=['location_id','HydroID','min_thal_elev','med_thal_elev','max_thal_elev', 'order_'])
+    closest_hydro_id = closest_catchment.filter(items=['location_id','HydroID','min_thal_elev','med_thal_elev','max_thal_elev', 'order_','feature_id_wrds','feature_id'])
     closest_hydro_id = closest_hydro_id.dropna()
 
     # Get USGS gages that are within catchment boundaries
     usgs_gages = usgs_gages.loc[usgs_gages.location_id.isin(list(closest_hydro_id.location_id))]
 
-    columns = ['location_id','HydroID','dem_elevation','dem_adj_elevation','min_thal_elev', 'med_thal_elev','max_thal_elev','str_order']
+    columns = ['location_id','HydroID','dem_elevation','dem_adj_elevation','min_thal_elev', 'med_thal_elev','max_thal_elev','str_order','feature_id_wrds','feature_id','gage_distance_to_line']
     gage_data = []
 
     # Move USGS gage to stream
@@ -68,6 +71,8 @@ def crosswalk_usgs_gage(usgs_gages_filename,dem_filename,input_flows_filename,in
         # Get stream attributes
         hydro_id = closest_hydro_id.loc[closest_hydro_id.location_id==gage.location_id].HydroID.item()
         str_order = str(int(closest_hydro_id.loc[closest_hydro_id.location_id==gage.location_id].order_.item()))
+        feat_id = str(closest_hydro_id.loc[closest_hydro_id.location_id==gage.location_id].feature_id.item())
+        feat_id_wrds = str(closest_hydro_id.loc[closest_hydro_id.location_id==gage.location_id].feature_id_wrds.item())
         min_thal_elev = round(closest_hydro_id.loc[closest_hydro_id.location_id==gage.location_id].min_thal_elev.item(),2)
         med_thal_elev = round(closest_hydro_id.loc[closest_hydro_id.location_id==gage.location_id].med_thal_elev.item(),2)
         max_thal_elev = round(closest_hydro_id.loc[closest_hydro_id.location_id==gage.location_id].max_thal_elev.item(),2)
@@ -98,7 +103,7 @@ def crosswalk_usgs_gage(usgs_gages_filename,dem_filename,input_flows_filename,in
         dem_adj_elev = round(list(rasterio.sample.sample_gen(dem_adj,shply_referenced_gage.coords))[0].item(),2)
 
         # Append dem_m_elev, dem_adj_elev, hydro_id, and gage number to table
-        site_elevations = [str(gage.location_id), str(hydro_id), dem_m_elev, dem_adj_elev, min_thal_elev, med_thal_elev, max_thal_elev,str(str_order)]
+        site_elevations = [str(gage.location_id), str(hydro_id), dem_m_elev, dem_adj_elev, min_thal_elev, med_thal_elev, max_thal_elev,str(str_order),str(feat_id_wrds),str(feat_id),gage_distance_to_line]
         gage_data.append(site_elevations)
 
     elev_table = pd.DataFrame(gage_data, columns=columns)
@@ -118,6 +123,7 @@ if __name__ == '__main__':
     parser.add_argument('-dem_adj','--dem-adj-filename', help='Thalweg adjusted DEM', required=True)
     parser.add_argument('-outtable','--output-table-filename', help='Table to append data', required=True)
     parser.add_argument('-e', '--extent', help="extent configuration entered by user when running fim_run.sh", required = True)
+    parser.add_argument('-huc','--huc8-id', help='HUC8 ID (to verify gage location huc)', type=str, required=True)
 
     args = vars(parser.parse_args())
 
@@ -129,5 +135,6 @@ if __name__ == '__main__':
     dem_adj_filename = args['dem_adj_filename']
     output_table_filename = args['output_table_filename']
     extent = args['extent']
+    huc8 = args['huc8_id']
 
-    crosswalk_usgs_gage(usgs_gages_filename,dem_filename,input_flows_filename,input_catchment_filename,wbd_buffer_filename, dem_adj_filename,output_table_filename, extent)
+    crosswalk_usgs_gage(usgs_gages_filename,dem_filename,input_flows_filename,input_catchment_filename,wbd_buffer_filename, dem_adj_filename,output_table_filename, extent,huc8)


### PR DESCRIPTION
This pull request adds an additional feature_id attribute associated with USGS gage locations (feature_id obtained from the WRDS API) output in the `usgs_gage_crosswalk.py`. There is also a new USGS gage query to check that gage HUC8 matches the FIM HUC when performing the gage-huc spatial query (avoids duplicating gages in multiple HUCs). Address #498 #502

## Changes

- `src/run_by_unit.sh`: updated to include the HUC8 id as an input argument to `usgs_gage_crosswalk.py` when running `fim_run.sh`
- `usgs_gage_crosswalk.py`: updated to include both `feature_id` (HAND-FIM crosswalked feature_id) and `feature_id_wrds` (feature_id assoicated with USGS gage location obtained from WRDS API). Also included the `gage_distance_to_line` attribute to potentially identify issues with correlating gage locations to the nearest thalweg pixel.

## Screenshots
Example of USGS gage that was previously associated to two different HUCS. UGSG gage 01357500 falls with the boundaries of HUC 02020004 but is also inside the wbd_buffered boundary for huc 02020003 (orange polygon). This pull request uses the HUC8 attribute within the USGS gage layer to perform a HUC query within 'usgs_gage_crosswalk.py`. The final result in gage 01357500 is now associated with huc 02020004 and not huc 02020003.
![image](https://user-images.githubusercontent.com/69868854/149189388-74014f77-bc95-4b9b-8e3b-f94083e03576.png)

Example of a new usgs_elev_table.csv for huc 02020003 with the new attributes highlighted in yellow
![image](https://user-images.githubusercontent.com/69868854/149189718-81528981-3182-47c4-8366-9784d28be417.png)


## Notes

- Check with team to determine if there are any pitfalls with this solution for ensuring gage is only associated with one HUC

## Todos

- Need to apply these changes to a full BED run for MS and FR
