### PR TITLE
Adding catchments and streams to aggregate outputs folder

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,6 +1,16 @@
 All notable changes to this project will be documented in this file.
 We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 
+## v3.0.24.9 - 2022-01-19 - [PR #506](https://github.com/NOAA-OWP/cahaba/pull/506)
+
+Adding catchments and streams layers to viz post-processing outputs
+
+## Additions
+- Added `catchments_{huc6}.gpkg` and `streams_{huc6}.gpkg` layers to aggregate_fim_outputs
+
+<br/><br/>
+
+
 ## v3.0.24.8 - 2022-01-12 - [PR #503](https://github.com/NOAA-OWP/cahaba/pull/503)
 
 This pull request adds an additional feature_id attribute associated with USGS gage locations (feature_id obtained from the WRDS API) output in the `usgs_gage_crosswalk.py`. There is also a new USGS gage query to ensure gage's HUC8 matches the FIM HUC when performing the gage-huc spatial query (avoids duplicating gages in multiple HUCs).

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,7 +3,7 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 
 ## v3.0.24.9 - 2022-01-19 - [PR #506](https://github.com/NOAA-OWP/cahaba/pull/506)
 
-Adding catchments and streams layers to viz post-processing outputs
+Adding catchments and streams layers to viz post-processing outputs.
 
 ## Additions
 - Added `catchments_{huc6}.gpkg` and `streams_{huc6}.gpkg` layers to aggregate_fim_outputs

--- a/src/aggregate_fim_outputs.py
+++ b/src/aggregate_fim_outputs.py
@@ -1,11 +1,14 @@
 #!/usr/bin/env python3
 
-import os
+from os import listdir, remove
+from os.path import split, dirname
+from pathlib import Path
 import argparse
 from multiprocessing import Pool
 import pandas as pd
+import geopandas as gpd
 import json
-import rasterio
+import rasterio as rio
 from rasterio.merge import merge
 from rasterio.warp import calculate_default_transform, reproject, Resampling
 import shutil
@@ -21,38 +24,44 @@ def aggregate_fim_outputs(args):
 
     print(f"aggregating {huc6}")
 
-    huc6_dir = os.path.join(fim_out_dir,'aggregate_fim_outputs',str(huc6))
-    os.makedirs(huc6_dir, exist_ok=True)
+    huc6_dir = Path(fim_out_dir / 'aggregate_fim_outputs' / f"{huc6}")
+    huc6_dir.mkdir(parents=True,exist_ok=True)
 
-    # aggregate file name paths
-    aggregate_hydrotable = os.path.join(fim_out_dir,'aggregate_fim_outputs',str(huc6),'hydroTable.csv')
-    aggregate_src = os.path.join(fim_out_dir,'aggregate_fim_outputs',str(huc6),f'rating_curves_{huc6}.json')
+    # Aggregate catchments
+    aggregate_catchments = Path(fim_out_dir / 'aggregate_fim_outputs' / str(huc6) / f'catchments_{huc6}.gpkg')
+    aggregate_streams = Path(fim_out_dir / 'aggregate_fim_outputs' / str(huc6) / f'streams_{huc6}.gpkg')
+    
+    # Aggregate file name paths
+    aggregate_hydrotable = Path(fim_out_dir / 'aggregate_fim_outputs' / str(huc6) / 'hydroTable.csv')
+    aggregate_src = Path(fim_out_dir / 'aggregate_fim_outputs' / str(huc6) / f'rating_curves_{huc6}.json')
 
     for huc in huc_list:
 
-        # original file paths
-        hydrotable_filename = os.path.join(fim_out_dir,huc,'hydroTable.csv')
-        src_filename = os.path.join(fim_out_dir,huc,'src.json')
+        # Original file paths
+        hydrotable_filename = Path(fim_out_dir / huc / 'hydroTable.csv')
+        src_filename = Path(fim_out_dir / huc / 'src.json')
+        streams_filename = Path(fim_out_dir / huc / 'demDerived_reaches_split_filtered_addedAttributes_crosswalked.gpkg')
+        catchments_filename = Path(fim_out_dir / huc / 'gw_catchments_reaches_filtered_addedAttributes_crosswalked.gpkg')
 
         if len(huc)> 6:
 
-            # open hydrotable
+            # Open hydrotable
             hydrotable = pd.read_csv(hydrotable_filename)
 
-            # write/append aggregate hydrotable
-            if os.path.isfile(aggregate_hydrotable):
+            # Write/append aggregate hydrotable
+            if aggregate_hydrotable.exists():
                 hydrotable.to_csv(aggregate_hydrotable,index=False, mode='a',header=False)
             else:
                 hydrotable.to_csv(aggregate_hydrotable,index=False)
 
             del hydrotable
 
-            # open src
+            # Open src
             src = open(src_filename)
             src = json.load(src)
 
-            # write/append aggregate src
-            if os.path.isfile(aggregate_src):
+            # Write/append aggregate src
+            if aggregate_src.exists():
 
                 with open(aggregate_src, "r+") as file:
                     data = json.load(file)
@@ -66,11 +75,33 @@ def aggregate_fim_outputs(args):
 
             del src
 
+            # Open streams
+            streams = gpd.read_file(streams_filename)
+
+            # Write/append aggregate hydrotable
+            if aggregate_streams.exists():
+                streams.to_file(aggregate_streams,index=False, mode='a',header=False,driver='GPKG')
+            else:
+                streams.to_file(aggregate_streams,index=False,driver='GPKG')
+
+            del streams
+
+            # Open catchments
+            catchments = gpd.read_file(catchments_filename)
+
+            # Write/append aggregate catchments
+            if aggregate_catchments.exists():
+                catchments.to_file(aggregate_catchments,index=False, mode='a',header=False,driver='GPKG')
+            else:
+                catchments.to_file(aggregate_catchments,index=False,driver='GPKG')
+
+            del catchments
+
         else:
             shutil.copy(hydrotable_filename, aggregate_hydrotable)
             shutil.copy(src_filename, aggregate_src)
 
-    ## add feature_id to aggregate src
+    ## Add feature_id to aggregate src
     # Open aggregate src for writing feature_ids to
     src_data = {}
     with open(aggregate_src) as jsonf:
@@ -87,18 +118,18 @@ def aggregate_fim_outputs(args):
     with open(aggregate_src, 'w') as jsonf:
         json.dump(src_data, jsonf)
 
-    ## aggregate rasters
-    # aggregate file paths
-    rem_mosaic = os.path.join(huc6_dir,f'hand_grid_{huc6}_prepprj.tif')
-    catchment_mosaic = os.path.join(huc6_dir,f'catchments_{huc6}_prepprj.tif')
+    ## Aggregate rasters
+    # Aggregate file paths
+    rem_mosaic = Path(huc6_dir / f'hand_grid_{huc6}_prepprj.tif')
+    catchment_mosaic = Path(huc6_dir / f'catchments_{huc6}_prepprj.tif')
 
     if huc6 not in huc_list:
 
         huc6_filter = [path.startswith(huc6) for path in huc_list]
         subset_huc6_list = [i for (i, v) in zip(huc_list, huc6_filter) if v]
 
-        # aggregate and mosaic rem
-        rem_list = [os.path.join(fim_out_dir,huc,'rem_zeroed_masked.tif') for huc in subset_huc6_list]
+        # Aggregate and mosaic rem
+        rem_list = [str(Path(fim_out_dir / huc / 'rem_zeroed_masked.tif')) for huc in subset_huc6_list]
 
         if len(rem_list) > 1:
 
@@ -106,14 +137,14 @@ def aggregate_fim_outputs(args):
 
             for rem in rem_list:
 
-                rem_src = rasterio.open(rem)
+                rem_src = rio.open(rem)
                 rem_files_to_mosaic.append(rem_src)
 
             mosaic, out_trans = merge(rem_files_to_mosaic)
             out_meta = rem_src.meta.copy()
             out_meta.update({"driver": "GTiff", "height": mosaic.shape[1], "width": mosaic.shape[2], "dtype": str(mosaic.dtype), "transform": out_trans,"crs": PREP_PROJECTION,'compress': 'lzw'})
 
-            with rasterio.open(rem_mosaic, "w", **out_meta, tiled=True, blockxsize=1024, blockysize=1024, BIGTIFF='YES') as dest:
+            with rio.open(rem_mosaic, "w", **out_meta, tiled=True, blockxsize=1024, blockysize=1024, BIGTIFF='YES') as dest:
                 dest.write(mosaic)
 
             del rem_files_to_mosaic,rem_src,out_meta,mosaic
@@ -122,15 +153,15 @@ def aggregate_fim_outputs(args):
 
             shutil.copy(rem_list[0], rem_mosaic)
 
-        # aggregate and mosaic catchments
-        catchment_list = [os.path.join(fim_out_dir,huc,'gw_catchments_reaches_filtered_addedAttributes.tif') for huc in subset_huc6_list]
+        # Aggregate and mosaic catchments
+        catchment_list = [str(Path(fim_out_dir / huc / 'gw_catchments_reaches_filtered_addedAttributes.tif')) for huc in subset_huc6_list]
 
         if len(catchment_list) > 1:
 
             cat_files_to_mosaic = []
 
             for cat in catchment_list:
-                cat_src = rasterio.open(cat)
+                cat_src = rio.open(cat)
                 cat_files_to_mosaic.append(cat_src)
 
             mosaic, out_trans = merge(cat_files_to_mosaic)
@@ -138,7 +169,7 @@ def aggregate_fim_outputs(args):
 
             out_meta.update({"driver": "GTiff", "height": mosaic.shape[1], "width": mosaic.shape[2], "dtype": str(mosaic.dtype), "transform": out_trans,"crs": PREP_PROJECTION,'compress': 'lzw'})
 
-            with rasterio.open(catchment_mosaic, "w", **out_meta, tiled=True, blockxsize=1024, blockysize=1024, BIGTIFF='YES') as dest:
+            with rio.open(catchment_mosaic, "w", **out_meta, tiled=True, blockxsize=1024, blockysize=1024, BIGTIFF='YES') as dest:
                 dest.write(mosaic)
 
             del cat_files_to_mosaic,cat_src,out_meta,mosaic
@@ -148,24 +179,24 @@ def aggregate_fim_outputs(args):
             shutil.copy(catchment_list[0], catchment_mosaic)
 
     else:
-        # original file paths
-        rem_filename = os.path.join(fim_out_dir,huc6,'rem_zeroed_masked.tif')
-        catchment_filename = os.path.join(fim_out_dir,huc6,'gw_catchments_reaches_filtered_addedAttributes.tif')
+        # Original file paths
+        rem_filename = Path(fim_out_dir / huc6 / 'rem_zeroed_masked.tif')
+        catchment_filename = Path(fim_out_dir / huc6 / 'gw_catchments_reaches_filtered_addedAttributes.tif')
 
         shutil.copy(rem_filename, rem_mosaic)
         shutil.copy(catchment_filename, catchment_mosaic)
 
-    ## reproject rasters
+    ## Reproject rasters
     reproject_raster(rem_mosaic,VIZ_PROJECTION)
-    os.remove(rem_mosaic)
+    remove(rem_mosaic)
 
     reproject_raster(catchment_mosaic,VIZ_PROJECTION)
-    os.remove(catchment_mosaic)
+    remove(catchment_mosaic)
 
 
 def reproject_raster(raster_name,reprojection):
 
-    with rasterio.open(raster_name) as src:
+    with rio.open(raster_name) as src:
         transform, width, height = calculate_default_transform(
             src.crs, reprojection, src.width, src.height, *src.bounds)
         kwargs = src.meta.copy()
@@ -177,14 +208,13 @@ def reproject_raster(raster_name,reprojection):
             'compress': 'lzw'
         })
 
-        raster_proj_rename = os.path.split(raster_name)[1].replace('_prepprj.tif', '.tif')
-        raster_proj_dir = os.path.join(os.path.dirname(raster_name), raster_proj_rename)
+        raster_proj_rename = split(raster_name)[1].replace('_prepprj.tif', '.tif')
+        raster_proj_dir = Path(dirname(raster_name), raster_proj_rename)
 
-        with rasterio.open(raster_proj_dir, 'w', **kwargs, tiled=True, blockxsize=1024, blockysize=1024, BIGTIFF='YES') as dst:
-            # for i in range(1, src.count + 1):
+        with rio.open(raster_proj_dir, 'w', **kwargs, tiled=True, blockxsize=1024, blockysize=1024, BIGTIFF='YES') as dst:
             reproject(
-                source=rasterio.band(src, 1),
-                destination=rasterio.band(dst, 1),
+                source=rio.band(src, 1),
+                destination=rio.band(dst, 1),
                 src_transform=src.transform,
                 src_crs=src.crs,
                 dst_transform=transform,
@@ -202,12 +232,12 @@ if __name__ == '__main__':
 
     args = vars(parser.parse_args())
 
-    fim_outputs_directory = args['fim_outputs_directory']
+    fim_outputs_directory = Path(args['fim_outputs_directory'])
     number_of_jobs = int(args['number_of_jobs'])
 
     drop_folders = ['logs']
-    huc_list = [huc for huc in os.listdir(fim_outputs_directory) if huc not in drop_folders]
-    huc6_list = [str(huc[0:6]) for huc in os.listdir(fim_outputs_directory) if huc not in drop_folders]
+    huc_list = [huc for huc in listdir(fim_outputs_directory) if huc not in drop_folders]
+    huc6_list = [str(huc[0:6]) for huc in listdir(fim_outputs_directory) if huc not in drop_folders]
     huc6_list = list(set(huc6_list))
 
     procs_list = []


### PR DESCRIPTION
Adding catchments and streams layers to viz post-processing outputs to resolve issue #501 

## Additions

- Added `catchments_{huc6}.gpkg` and `streams_{huc6}.gpkg` to `aggregate_fim_outputs`

## Changes

- Cleaned up imports and switched to `Path` library where applicable 

## Testing

- Outputs are located in `fim_3_0_24_2_fim_run_ms`