### PR TITLE
Adding usgs_elev_table.csv to the -viz cleanup whitelist

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,6 +1,16 @@
 All notable changes to this project will be documented in this file.
 We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 
+## v3.0.24.12 - 2022-01-26 - [PR #512](https://github.com/NOAA-OWP/cahaba/pull/512)
+
+Hotfix to include the `usgs_elev_table.csv` in the `-v` (viz) file cleanup within `output_cleanup.py`. This file is needed for sierra test input and corresponding rating curve evaluation services.
+
+## Changes
+
+- `output_cleanup.py`: added `usgs_elev_table.csv` to list of whitelist files
+
+<br/><br/>
+
 ## v3.0.24.11 - 2022-01-24 - [PR #508](https://github.com/NOAA-OWP/cahaba/pull/508)
 
 Adds a tool that can be used to compare water surface elevation (WSE) between FIM synthetic rating curves and USGS/AHPS rating curves. There are also some enhancements made to the sierra test (`tools/rating_curve_comparison.py`), including updated rating curve comparison plots.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,11 +3,11 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 
 ## v3.0.24.12 - 2022-01-26 - [PR #512](https://github.com/NOAA-OWP/cahaba/pull/512)
 
-Hotfix to include the `usgs_elev_table.csv` in the `-v` (viz) file cleanup within `output_cleanup.py`. This file is needed for sierra test input and corresponding rating curve evaluation services.
+Hotfix to include the `usgs_elev_table.csv` in the `-v` (viz) file cleanup within `output_cleanup.py`. This file is needed for Sierra Test input and corresponding rating curve evaluation services.
 
 ## Changes
 
-- `output_cleanup.py`: added `usgs_elev_table.csv` to list of whitelist files
+- `output_cleanup.py`: added `usgs_elev_table.csv` to list of whitelist files.
 
 <br/><br/>
 

--- a/src/output_cleanup.py
+++ b/src/output_cleanup.py
@@ -53,6 +53,7 @@ def output_cleanup(huc_number, output_folder_path, additional_whitelist, is_prod
         'src_full_crosswalked.csv',
         'demDerived_reaches_split_points.gpkg',
         'flowdir_d8_burned_filled.tif',
+        'usgs_elev_table.csv',
         'dem_thalwegCond.tif'
     ]
 


### PR DESCRIPTION
Hotfix to include the `usgs_elev_table.csv` in the -viz file cleanup within `output_cleanup.py`. This file is needed for sierra test input and corresponding rating curve evaluation services.

## Changes

- `output_cleanup.py`: added `usgs_elev_table.csv` to list of whitelist files