### PR TITLE
[1pt] PR: Hotfix for usgs_gage_crosswalk.py error in Hawaiian HUCs

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,6 +1,17 @@
 All notable changes to this project will be documented in this file.
 We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 
+
+## v3.0.24.14 - 2022-01-31 - [PR #515](https://github.com/NOAA-OWP/cahaba/pull/515)
+
+Hotfix to correct the bug introduced in two Hawaiian HUCs when `usgs_gage_crosswalk.py` includes AHPS points.
+
+## Changes
+
+- `src/usgs_gage_crosswalk.py`: Use `pygeos.coordinates.get_coordinates()` to get the snapped coordinates instead of converting to shapley objects to get the coordinates. Using `pygoes` ensures that any Z-values are not included in the coordinates.
+
+<br/><br/>
+
 ## v3.0.24.13 - 2022-01-31 - [PR #514](https://github.com/NOAA-OWP/cahaba/pull/514)
 
 This feature branch includes minor enhancements to the SRC adjustment tools including a new attribute appended to the hydroID catchments .gpkg and an optional input argument to override the default downstream distance threshold for roughness application.

--- a/src/usgs_gage_crosswalk.py
+++ b/src/usgs_gage_crosswalk.py
@@ -101,15 +101,9 @@ def crosswalk_usgs_gage(usgs_gages_filename,nws_lid_filename,dem_filename,input_
         gage_distance_to_line = pygeos.linear.line_locate_point(stream_bin_geom, gage_bin_geom)
         referenced_gage = pygeos.linear.line_interpolate_point(stream_bin_geom, gage_distance_to_line)
 
-        # Convert geometries to wkb representation
-        bin_referenced_gage = pygeos.io.to_wkb(referenced_gage)
-
-        # Convert to shapely geometries
-        shply_referenced_gage = loads(bin_referenced_gage)
-
         # Sample rasters at adjusted gage
-        dem_m_elev = round(list(rasterio.sample.sample_gen(dem_m,shply_referenced_gage.coords))[0].item(),2)
-        dem_adj_elev = round(list(rasterio.sample.sample_gen(dem_adj,shply_referenced_gage.coords))[0].item(),2)
+        dem_m_elev = round(list(rasterio.sample.sample_gen(dem_m,pygeos.coordinates.get_coordinates(referenced_gage)))[0].item(),2)
+        dem_adj_elev = round(list(rasterio.sample.sample_gen(dem_adj,pygeos.coordinates.get_coordinates(referenced_gage)))[0].item(),2)
 
         # Append dem_m_elev, dem_adj_elev, hydro_id, and gage number to table
         site_elevations = [str(gage.location_id), str(gage.nws_lid), str(hydro_id), dem_m_elev, dem_adj_elev, min_thal_elev, med_thal_elev, max_thal_elev,str(str_order),str(feat_id_wrds),str(feat_id),gage_distance_to_line]


### PR DESCRIPTION
Hotfix for usgs_gage_crosswalk.py error in Hawaiian HUCs `20020000` & `20070000`

## Changes

- `src/usgs_gage_crosswalk.py`: Use `pygeos.coordinates.get_coordinates()` to get the snapped coordinates instead of converting to shapley objects to get the coordinates. Using `pygoes` ensures that any Z-values are not included in the coordinates.
