### PR TITLE
[1pt] PR: Adds basic unit test capabilities

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,7 +4,7 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 
 ## v4.0.1.0 - 2022-02-02 - [PR #525](https://github.com/NOAA-OWP/cahaba/pull/525)
 
-The addition of a very simple and evolving unit test system which has two unit tests against two py files.  This will set a precendence and will grow over time to become a full automated, possibly git checkin triggered, unit test system. The embedded README.md has more details of what we currently have, how to use it, how to add new unit tests, and expected future enhancements.
+The addition of a very simple and evolving unit test system which has two unit tests against two py files.  This will set a precendence and will grow over time and may be automated, possibly during git check-in triggered. The embedded README.md has more details of what we currently have, how to use it, how to add new unit tests, and expected future enhancements.
 
 ## Additions
 
@@ -20,7 +20,7 @@ The addition of a very simple and evolving unit test system which has two unit t
 
    - `gms/derive_level_paths_params.json`: A set of default "happy path" values that are expected to pass validation for the derive_level_paths_params.py -> Derive_level_paths (function). 
 
-   - `gms/derive_level_paths_unittests.py`: A unit test file for src/derive_level_paths.py. Incomplete but evolving.
+   - `gms/derive_level_paths_unittests.py`: A unit test file for `src/derive_level_paths.py`. Incomplete but evolving.
 
 <br/><br/>
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,6 +1,30 @@
 All notable changes to this project will be documented in this file.
 We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 
+
+## v4.0.1.0 - 2022-02-02 - [PR #525](https://github.com/NOAA-OWP/cahaba/pull/525)
+
+The addition of a very simple and evolving unit test system which has two unit tests against two py files.  This will set a precendence and will grow over time to become a full automated, possibly git checkin triggered, unit test system. The embedded README.md has more details of what we currently have, how to use it, how to add new unit tests, and expected future enhancements.
+
+## Additions
+
+- `/unit_tests/` folder which has the following:
+
+   - `clip_vectors_to_wbd_params.json`: A set of default "happy path" values that are expected to pass validation for the clip_vectors_to_wbd.py -> clip_vectors_to_wbd (function).
+
+   - `clip_vectors_to_wbd_unittests.py`: A unit test file for src/clip_vectors_to_wbd.py. Incomplete but evolving.
+
+   - `README.md`: Some information about how to create unit tests and how to use them.
+
+   - `unit_tests_utils.py`: A python file where methods that are common to all unit tests can be placed.
+
+   - `gms/derive_level_paths_params.json`: A set of default "happy path" values that are expected to pass validation for the derive_level_paths_params.py -> Derive_level_paths (function). 
+
+   - `gms/derive_level_paths_unittests.py`: A unit test file for src/derive_level_paths.py. Incomplete but evolving.
+
+<br/><br/>
+
+
 ## v4.0.0.0 - 2022-02-01 - [PR #524](https://github.com/NOAA-OWP/cahaba/pull/524)
 
 FIM4 builds upon FIM3 and allows for better representation of inundation through the reduction of artificial restriction of inundation at catchment boundaries.

--- a/unit_tests/README.md
+++ b/unit_tests/README.md
@@ -36,9 +36,9 @@ At the root terminal window, run:  python ./foss_fim/unit_tests/gms/derive_level
 
 
 ## Key Notes for creating new unit tests
-1) All test methods must start with the phrase "test_". That is how the unit test engine picks it up.
+1) All test functions must start with the phrase "test_". That is how the unit test engine picks it up. The rest of the function name does not have to match the pattern of {function name being tested} but should. Further, the rest of the function name should say what the test is about, ie) _failed_input_path.  ie) test_{some_function_name_from_the_source_code_file}_failed_input_path. It is fine that the function names get very long (common in the industry).
 
-2) The output for a selected "unittest" import engine can be ugly and hard to read. It sometimes mixed outputs from multiple unit test methods simulataneously instead of keeping all output together for a given unit test. We will try to make this better later.
+2) The output for a selected "unittest" import engine can be ugly and hard to read. It sometimes mixed outputs from multiple unit test functions simulataneously instead of keeping all output together for a given unit test. We will try to make this better later.
 
 3) If you are using this for development purposes, use caution when checking back in files for unit tests files and json file. If you check it in, it still has to work and work for others and not just for a dev test you are doing.
 
@@ -46,7 +46,9 @@ At the root terminal window, run:  python ./foss_fim/unit_tests/gms/derive_level
 
 5) There must be at one "{original py file name}_params.json" file.
 
-6) There must be at least one "happy path" test inside the unittest file. ie) one function that is expected to full pass. You can have multiple "happy path" tests if you want to change values that are fundamentally different, but fully expected to pass.
+6) There must be at least one "happy path (successful)" test inside the unittest file. ie) one function that is expected to full pass. You can have multiple "happy path" tests if you want to change values that are fundamentally different, but fully expected to pass.
+
+7) Unit test functions can and should test for all "outputs" from a source function. This includes the functions's return output, but any global variables it might set, and even that saved output files (such as .tif files) have been created and successfully. It is ok to have multiple validation checks (or asserts) in one unit test function.
 
 7) One py file = one "{original py file name}_unittests.py" file.
 
@@ -60,15 +62,17 @@ At the root terminal window, run:  python ./foss_fim/unit_tests/gms/derive_level
 
 4) At this time, the root json file has only one "node". We may consider have more than one node in the json file, which has a different set of data for different test conditions. 
 
+5) Over time, it is expected that python code files will be broken down to many functions inside the file. Currently, we tend to have one very large function in each code file which makes unit testing harder and less specific. Generally for each function in a python code file will result in at least one "happy path" unit test function. This might require having test unit test outputs, such as sample tif or small gpkg files in subfolders in the unit tests folder, but this remains to be seen. Note: Our first two files of derive_level_paths_unittests and clip_vectors_to_wbd_unittests are not complete as they do not yet test all output from a method.
+
 
 ## testing for failing conditions
-- Over time, you want to start adding functions that specifically look for fail conditions. This is a key part of unit test systems. It is not uncommon to have many dozens of tests methods in one unit test file. Each "fail" type test, must check for `ONLY one variable value change`. Aka.. a "fail" test method should not fundamentally pass in an invalid huc AND an invalid file path.  Those two failing test conditions and must have two seperate unit test methods. 
+- Over time, you want to start adding functions that specifically look for fail conditions. This is a key part of unit test systems. It is not uncommon to have many dozens of tests functions in one unit test file. Each "fail" type test, must check for `ONLY one variable value change`. Aka.. a "fail" test function should not fundamentally pass in an invalid huc AND an invalid file path.  Those two failing test conditions and must have two seperate unit test functions. 
 
-- It is possible to let a unit test have more than one failed value but only if they are tightly related to trigger just one failure (RARE though). YES.. Over time, we will see TONS of these types of fail unit test methods and they will take a while to run.
+- It is possible to let a unit test have more than one failed value but only if they are tightly related to trigger just one failure (RARE though). YES.. Over time, we will see TONS of these types of fail unit test functions and they will take a while to run.
 
-- When you create a "fail" test method, you can load up the normal full "params" from the json file, but then you can override (hardcoded) the one (or rarely more than one) variable inside the function. There is a way to "catch" a failure you are expecting, ensure it is the type of failure you expected and make that "failure" to become a true fail, ie) a unit test pass. 
+- When you create a "fail" test function, you can load up the normal full "params" from the json file, but then you can override (hardcoded) the one (or rarely more than one) variable inside the function. There is a way to "catch" a failure you are expecting, ensure it is the type of failure you expected and make that "failure" to become a true fail, ie) a unit test pass. 
 
-An example is in unit_tests/gms/Derive_level_paths_unittests.py -> test_Derive_level_paths_invalid_input_stream_network (method). It is incomplete but give you the pattern.
+An example is in unit_tests/gms/Derive_level_paths_unittests.py -> test_Derive_level_paths_invalid_input_stream_network (function). It is incomplete but give you the pattern.
 
 We have almost no "assert"s yet, but most unit test usually have one or more "assert" test. See https://docs.python.org/3/library/unittest.html for more details.
 

--- a/unit_tests/README.md
+++ b/unit_tests/README.md
@@ -1,0 +1,75 @@
+## Cahaba: Flood Inundation Mapping for U.S. National Water Model
+
+Flood inundation mapping software configured to work with the U.S. National Water Model operated and maintained by the National Oceanic and Atmospheric Administration (NOAA) National Water Center (NWC).
+
+#### For more information, see the [Cahaba Wiki](https://github.com/NOAA-OWP/cahaba/wiki).
+
+### This folder and files are for unit testing python files
+
+## Creating unit tests
+
+For each python code file that is being tested, unit tests should come in two files: a unit test file (based on the original python code file) and it's json parms file. 
+
+The files should be named following FIM convention:
+
+{source py file name}_unittests.py     ie) derive_level_paths_unittests.py
+{source py file name}_params.json      ie) derive_level_paths_params.json
+
+
+## Tips to creating a new json file for a new unit test file.
+
+There are multiple way to figure out a set of default json parameters for the new unit test file. 
+
+One way is to use the incoming arg parser. Most py files, they include the code block of " __name__ == '__main__':", followed by external arg parsing, ie) the args = vars(parser.parse_args()). 
+	- Add a print(args) or similar, and get all the values including keys as output.
+	- Copy that into an editor being used to create the json file.
+	- Add a line break after every comma.
+	- Find/replace all single quotes to double quotes then cleanup the left tab formatting.
+
+
+## Running unit tests
+
+Start a docker container as you normally would for any development. ie) docker run --rm -it --name rob_levelpaths -v /home/{your name}/projects/gms_ms_level_paths/fim_4/:/foss_fim {your docker image name}
+
+At the root terminal window, run:  python ./foss_fim/unit_tests/gms/derive_level_paths_unittests.py  or python ./foss_fim/unit_tests/clip_vectors_to_wbd_unittests.py
+(replace with your own script and path name)
+
+
+## Key Notes for creating new unit tests
+1) All test methods must start with the phrase "test_". That is how the unit test engine picks it up.
+
+2) The output for a selected "unittest" import engine can be ugly and hard to read. It sometimes mixed outputs from multiple unit test methods simulataneously instead of keeping all output together for a given unit test. We will try to make this better later.
+
+3) If you are using this for development purposes, use caution when checking back in files for unit tests files and json file. If you check it in, it still has to work and work for others and not just for a dev test you are doing.
+
+4) You can not control the order that unit tests are run within a unit test file. (UnitTest engine limitation)
+
+5) There must be at one "{original py file name}_params.json" file.
+
+6) There must be at least one "happy path" test inside the unittest file. ie) one function that is expected to full pass. You can have multiple "happy path" tests if you want to change values that are fundamentally different, but fully expected to pass.
+
+7) One py file = one "{original py file name}_unittests.py" file.
+
+
+## Future Enhancements
+1) We can automate triggers on these files for things like checking triggers or an single global "run_all_unittest" script, but for now.. its one offs.
+
+2) Better output from the unit tests.
+
+3) We will upgrade it so you can pass in a params.json file to the call to give you even more flexibility by passing in your own params.json (think params_template.json idea)
+
+4) At this time, the root json file has only one "node". We may consider have more than one node in the json file, which has a different set of data for different test conditions. 
+
+
+## testing for failing conditions
+- Over time, you want to start adding functions that specifically look for fail conditions. This is a key part of unit test systems. It is not uncommon to have many dozens of tests methods in one unit test file. Each "fail" type test, must check for `ONLY one variable value change`. Aka.. a "fail" test method should not fundamentally pass in an invalid huc AND an invalid file path.  Those two failing test conditions and must have two seperate unit test methods. 
+
+- It is possible to let a unit test have more than one failed value but only if they are tightly related to trigger just one failure (RARE though). YES.. Over time, we will see TONS of these types of fail unit test methods and they will take a while to run.
+
+- When you create a "fail" test method, you can load up the normal full "params" from the json file, but then you can override (hardcoded) the one (or rarely more than one) variable inside the function. There is a way to "catch" a failure you are expecting, ensure it is the type of failure you expected and make that "failure" to become a true fail, ie) a unit test pass. 
+
+An example is in unit_tests/gms/Derive_level_paths_unittests.py -> test_Derive_level_paths_invalid_input_stream_network (method). It is incomplete but give you the pattern.
+
+We have almost no "assert"s yet, but most unit test usually have one or more "assert" test. See https://docs.python.org/3/library/unittest.html for more details.
+
+

--- a/unit_tests/clip_vectors_to_wbd_params.json
+++ b/unit_tests/clip_vectors_to_wbd_params.json
@@ -1,0 +1,23 @@
+{
+	"hucCode": "05030104",
+	"nwm_streams": "/data/inputs/nwm_hydrofabric/nwm_flows.gpkg",
+	"nhd_streams": "/data/inputs/nhdplus_vectors_aggregate/agg_nhd_streams_adj.gpkg", 
+	"nwm_lakes": "/data/inputs/nwm_hydrofabric/nwm_lakes.gpkg",
+	"nld_lines": "/data/inputs/nld_vectors/huc2_levee_lines/nld_preprocessed_05.gpkg",
+	"wbd": "/data/outputs/level_paths_3/05030104/wbd.gpkg",
+	"wbd_buffer": "/data/outputs/level_paths_3/05030104/wbd_buffered.gpkg",
+	"nwm_catchments": "/data/inputs/nwm_hydrofabric/nwm_catchments.gpkg", 
+	"nhd_headwaters": "/data/inputs/nhdplus_vectors_aggregate/agg_nhd_headwaters_adj.gpkg",
+	"landsea": "/data/inputs/landsea/water_polygons_us.gpkg",
+	"subset_nhd_streams": "/data/outputs/level_paths_3/05030104/NHDPlusBurnLineEvent_subset.gpkg",
+	"subset_nld_lines": "/data/outputs/level_paths_3/05030104/nld_subset_levees.gpkg", 
+	"subset_lakes": "/data/outputs/level_paths_3/05030104/nwm_lakes_proj_subset.gpkg",
+	"subset_catchments": "/data/outputs/level_paths_3/05030104/nwm_catchments_proj_subset.gpkg",
+	"subset_nhd_headwaters": "/data/outputs/level_paths_3/05030104/nhd_headwater_points_subset.gpkg", 
+	"subset_nwm_streams": "/data/outputs/level_paths_3/05030104/nwm_subset_streams.gpkg", 
+	"subset_landsea": "/data/outputs/level_paths_3/05030104/LandSea_subset.gpkg", 
+	"extent": "GMS",
+	"great_lakes_filename": "/data/inputs/landsea/gl_water_polygons.gpkg", 
+	"wbd_buffer_distance": 5000,
+	"lake_buffer_distance": 20
+}

--- a/unit_tests/clip_vectors_to_wbd_unittests.py
+++ b/unit_tests/clip_vectors_to_wbd_unittests.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+
+import inspect
+import os
+import sys
+
+import argparse
+import json
+import unittest
+
+import unit_tests_utils as helpers
+
+# importing python folders in other direcories
+sys.path.append('/foss_fim/src/')
+import clip_vectors_to_wbd
+
+# NOTE: This goes directly to the function.
+# Ultimately, it should emulate going through command line (not import -> direct function call)
+class test_clip_vectors_to_wbd(unittest.TestCase):
+
+    '''
+    Allows the params to be loaded one and used for all test methods
+    '''
+    @classmethod
+    def setUpClass(self):
+
+        params_file_path = '/foss_fim/unit_tests/clip_vectors_to_wbd_params.json'
+    
+        with open(params_file_path) as params_file:
+            self.params = json.load(params_file)
+
+
+    # MUST start with the name of "test_"
+    def test_subset_vector_layers_success(self):
+
+        #global params_file
+        helpers.print_unit_test_function_header()
+        
+        params = self.params
+        
+        '''
+        This NEEDS be upgraded to check the output, as well as the fact that all of the output files exist as expected.
+        Most of the output test and internal tests with this function will test a wide variety of conditions.
+        For subcalls to other py classes will not exist in this file, but the unittest file for the other python file.
+        Only the basic return output value shoudl be tested to ensure it is as expected.
+        For now, we are adding the very basic "happy path" test.
+        '''
+       
+        # There is no default return value.
+        # Later we need to check in this function that files were being created on the file system
+        
+        # for now we are happy if no exceptions are thrown.
+        clip_vectors_to_wbd.subset_vector_layers(hucCode = params["hucCode"],
+                                                nwm_streams_filename = params["nwm_streams"],
+                                                nhd_streams_filename = params["nhd_streams"],
+                                                nwm_lakes_filename = params["nwm_lakes"],
+                                                nld_lines_filename = params["nld_lines"],
+                                                nwm_catchments_filename = params["nwm_catchments"],
+                                                nhd_headwaters_filename = params["nhd_headwaters"],
+                                                landsea_filename = params["landsea"],
+                                                wbd_filename = params["wbd"],
+                                                wbd_buffer_filename = params["wbd_buffer"],
+                                                subset_nhd_streams_filename = params["subset_nhd_streams"],
+                                                subset_nld_lines_filename = params["subset_nld_lines"],
+                                                subset_nwm_lakes_filename = params["subset_lakes"],
+                                                subset_nwm_catchments_filename = params["subset_catchments"],
+                                                subset_nhd_headwaters_filename = params["subset_nhd_headwaters"],
+                                                subset_nwm_streams_filename = params["subset_nwm_streams"],
+                                                subset_landsea_filename = params["subset_landsea"],
+                                                extent = params["extent"],
+                                                great_lakes_filename = params["great_lakes_filename"],
+                                                wbd_buffer_distance = params["wbd_buffer_distance"],
+                                                lake_buffer_distance = params["lake_buffer_distance"])
+       
+       
+
+       
+        print(f"Test Success: {inspect.currentframe().f_code.co_name}")
+        print("*************************************************************")
+
+
+if __name__ == '__main__':
+
+    script_file_name = os.path.basename(__file__)
+
+    print("*****************************")
+    print(f"Start of {script_file_name} tests")
+    print()
+   
+    unittest.main()
+    
+    print()    
+    print(f"End of {script_file_name} tests")
+    

--- a/unit_tests/gms/derive_level_paths_params.json
+++ b/unit_tests/gms/derive_level_paths_params.json
@@ -1,0 +1,14 @@
+{
+	"in_stream_network": "/data/outputs/level_paths_1/03110201/nwm_subset_streams.gpkg",
+	"out_stream_network": "/data/outputs/level_paths_1/03110201/nwm_subset_streams_levelPaths.gpkg",
+	"branch_id_attribute": "levpa_id",
+	"out_stream_network_dissolved": "/data/outputs/level_paths_1/03110201/nwm_subset_streams_levelPaths.gpkg",
+	"headwaters_outfile": "/data/outputs/level_paths_1/03110201/nwm_headwaters.gpkg",
+	"catchments": "/data/outputs/level_paths_1/03110201/nwm_catchments_proj_subset.gpkg",
+	"catchments_outfile": "/data/outputs/level_paths_1/03110201/nwm_catchments_proj_subset_levelPaths.gpkg",
+	"branch_inlets_outfile": "/data/outputs/level_paths_1/03110201/nwm_subset_streams_levelPaths_dissolved_headwaters.gpkg",
+	"reach_id_attribute": "ID",
+	"verbose": false
+}
+
+

--- a/unit_tests/gms/derive_level_paths_unittests.py
+++ b/unit_tests/gms/derive_level_paths_unittests.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+
+import inspect
+import os
+import sys
+import unittest
+
+import json
+
+# importing python folders in other direcories
+sys.path.append('/foss_fim/unit_tests/')
+import unit_tests_utils as helpers
+
+# importing python folders in other direcories
+sys.path.append('/foss_fim/src/gms/')
+import derive_level_paths
+
+
+# NOTE: This goes directly to the function.
+# Ultimately, it should emulate going through command line (not import -> direct function call)
+class test_Derive_level_paths(unittest.TestCase):
+
+    '''
+    Allows the params to be loaded one and used for all test methods
+    '''
+    @classmethod
+    def setUpClass(self):
+    
+        params_file_path = '/foss_fim/unit_tests/gms/derive_level_paths_params.json'    
+    
+        with open(params_file_path) as params_file:
+            self.params = json.load(params_file)
+
+
+    # MUST start with the name of "test_"
+    def test_Derive_level_paths_success(self):
+       
+        helpers.print_unit_test_function_header()
+        
+        params = self.params
+
+        # Function Notes:
+        # huc_ids no longer used, so it is not submitted
+        # other params such as toNode_attribute and fromNode_attribute are defaulted and not passed into __main__, so I will
+        # skip them here.
+        actual = derive_level_paths.Derive_level_paths(in_stream_network = params["in_stream_network"],
+                                                       out_stream_network = params["out_stream_network"],
+                                                       branch_id_attribute = params["branch_id_attribute"],
+                                                       out_stream_network_dissolved = params["out_stream_network_dissolved"],
+                                                       headwaters_outfile = params["headwaters_outfile"],
+                                                       catchments = params["catchments"],
+                                                       catchments_outfile = params["catchments_outfile"],
+                                                       branch_inlets_outfile = params["branch_inlets_outfile"],
+                                                       reach_id_attribute = params["reach_id_attribute"],
+                                                       verbose = params["verbose"] )
+        
+        
+        '''
+        This NEEDS be upgraded to check the output, as well as the fact that all of the output files exist as expected.
+        Most of the output test and internal tests with this function will test a wide variety of conditions.
+        For subcalls to other py classes will not exist in this file, but the unittest file for the other python file.
+        Only the basic return output value shoudl be tested to ensure it is as expected.
+        For now, we are adding the very basic "happy path" test.
+        '''
+        
+        print(actual)
+        
+        # Later, we should check here that the files outputed to the file system, exist and are valid and those do not have to be new "test_" methods.
+        # We can start using unit test "asserts" as we go as well.
+        
+        print(f"Test Success: {inspect.currentframe().f_code.co_name}")
+        print("*************************************************************")        
+
+
+    # Invalid Input stream
+    # MUST start with the name of "test_"    
+    def test_Derive_level_paths_invalid_input_stream_network(self):
+
+        helpers.print_unit_test_function_header()        
+        
+        try:
+        
+            params = self.params
+            #with open("/foss_fim/unit_tests/gms/derive_level_paths_params.json") as params_file:
+            #    params = json.load(params_file)
+
+            bad_input_stream_network = "some bad path"
+           
+            actual = derive_level_paths.Derive_level_paths(in_stream_network = bad_input_stream_network,
+                                                           out_stream_network = params["out_stream_network"],
+                                                           branch_id_attribute = params["branch_id_attribute"],
+                                                           out_stream_network_dissolved = params["out_stream_network_dissolved"],
+                                                           huc_id = params["huc_id"],
+                                                           headwaters_outfile = params["headwaters_outfile"],
+                                                           catchments = params["catchments"],
+                                                           catchments_outfile = params["catchments_outfile"],
+                                                           branch_inlets_outfile = params["branch_inlets_outfile"],
+                                                           reach_id_attribute = params["reach_id_attribute"],
+                                                           verbose = params["verbose"] )
+                                                           
+            raise AssertionError("Fail = excepted a thrown exception but did not get it but was received. Unit Test has 'failed'")
+            
+        except Exception as ex:
+            print()
+            print(f"Test Success (failed as expected): {inspect.currentframe().f_code.co_name}")
+            print(ex)
+            
+        finally:
+            print("*************************************************************")             
+        
+if __name__ == '__main__':
+
+    print("*****************************")
+    print(f"Start of {os.path.basename(__file__)} tests")
+    print()
+            
+    unittest.main()
+    
+    print()    
+    print(f"End of {os.path.basename(__file__)} tests")
+    

--- a/unit_tests/unit_tests_utils.py
+++ b/unit_tests/unit_tests_utils.py
@@ -1,0 +1,11 @@
+#!/usr/bin/env python3
+
+import sys
+
+
+def print_unit_test_function_header():
+
+    print()    
+    print("*************************************************************") 
+    print(f"Start function: {sys._getframe(1).f_code.co_name}")
+    print()


### PR DESCRIPTION
This is the start of a very basic unit test system. I can also be used to assist in development efforts. Over time, more python files can have unit tests files created for them. Additional unit tests within unit test files will likely also be add (especially for "fail" conditions where one wants to ensure that bad data is being handled correctly in the code.

## Additions

- A new unit_tests folder which has the following:
   - clip_vectors_to_wbd_params.json:  A set of default "happy path" values that are expected to pass validation for the   clip_vectors_to_wbd.py -> clip_vectors_to_wbd (function). 
   - clip_vectors_to_wbd_unittests.py: A unit test file for src/clip_vectors_to_wbd.py. This file has only one test in it for happy path, but more are expected as "fail" test conditions are added later.
   - README.md:  Some information about how to create unit tests and how to use them.
   - unit_tests_utils.py: A python file where methods that are common to all tests can be placed. At this point, only one is included to create consistancy in unit path output print headers.
   - gms/derive_level_paths_params.json: A set of default "happy path" values that are expected to pass validation for the   derive_level_paths_params.py -> Derive_level_paths (function).  Note: the original method started with an upper case "D", so it used here as well. 

   -  gms/derive_level_paths_unittests.py: A unit test file for src/derive_level_paths.py. This file has only one test in it for happy path, but more are expected as "fail" test conditions are added later. Also, the "happy path (success)" function is not complete. it currently is evaluating the output only. 

## Notes

This is a very basic "starting" system. Even the two included unit test files are incomplete, but they have value even now for development purposes. This will hopefully create some precedence's that evolve. Eventually, the unit test system can become a tool that is triggered based on git checkin's to validate that a change has not broken other code functionality in other places.

